### PR TITLE
Add create-component script (closes #43)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "watch:build": "webpack --watch",
     "watch:server": "nodemon \"./index.js\" --watch \"./dadi\"",
     "snyk-protect": "snyk protect",
-    "prepublish": "npm run snyk-protect"
+    "prepublish": "npm run snyk-protect",
+    "create-component": "bash scripts/create-component/create-component.sh"
   },
   "repository": {
     "type": "git",

--- a/scripts/create-component/components.template.jsx
+++ b/scripts/create-component/components.template.jsx
@@ -1,0 +1,18 @@
+'use strict'
+
+import {h, Component} from 'preact'
+
+import Style from 'lib/Style'
+import styles from './{NAME}.css'
+
+export default class {NAME} extends Component {
+  constructor(props) {
+    super(props)
+  }
+
+  render() {
+    return (
+      <p>{NAME}</p>
+    )
+  }
+}

--- a/scripts/create-component/containers.template.jsx
+++ b/scripts/create-component/containers.template.jsx
@@ -1,0 +1,19 @@
+import {h, Component} from 'preact'
+import {connect} from 'preact-redux'
+import {bindActionCreators} from 'redux'
+import {connectHelper} from 'lib/util'
+
+class {NAME} extends Component {
+  render() {
+    const { type } = this.props
+
+    return (
+      <p>{NAME}</p>
+    )
+  }
+}
+
+export default connectHelper(
+  state => state,
+  dispatch => bindActionCreators({}, dispatch)
+)({NAME})

--- a/scripts/create-component/create-component.sh
+++ b/scripts/create-component/create-component.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+
+echo ""
+echo "What type of component do you want to create?"
+echo ""
+echo "> 1: Component"
+echo "> 2: Container"
+echo "> 3: View"
+echo ""
+
+read component_type_option
+
+case $component_type_option in
+'1')
+  component_type="components"
+;;
+'2')
+  component_type="containers"
+;;
+'3')
+  component_type="views"
+;;
+*)
+  echo "ERROR: Unknown component type"
+  exit 1
+esac
+
+echo ""
+echo "What's the name of the component?"
+echo ""
+
+read component_name
+
+if [ -d "$parent_path/../../dadi/frontend/$component_type/$component_name" ]; then
+  echo "ERROR: Component already exists"
+  exit 1
+fi
+
+cp "$parent_path/$component_type.template.jsx" "$parent_path/$component_name.jsx"
+sed -ie "s/{NAME}/$component_name/g" "$parent_path/$component_name.jsx"
+
+# Creating directory
+mkdir "$parent_path/../../dadi/frontend/$component_type/$component_name"
+
+# Moving component file
+mv "$parent_path/$component_name.jsx" "$parent_path/../../dadi/frontend/$component_type/$component_name"
+
+# Creating CSS
+touch "$parent_path/../../dadi/frontend/$component_type/$component_name/$component_name.css"
+
+echo ""
+echo "Done! $component_name component has been created."
+echo ""

--- a/scripts/create-component/views.template.jsx
+++ b/scripts/create-component/views.template.jsx
@@ -1,0 +1,19 @@
+import {h, Component} from 'preact'
+import {connect} from 'preact-redux'
+import {bindActionCreators} from 'redux'
+import {connectHelper} from 'lib/util'
+
+class {NAME} extends Component {
+  render() {
+    const { type } = this.props
+
+    return (
+      <p>{NAME}</p>
+    )
+  }
+}
+
+export default connectHelper(
+  state => state,
+  dispatch => bindActionCreators({}, dispatch)
+)({NAME})


### PR DESCRIPTION
This PR adds a simple Bash script to create components, as per #43.

It can be executed with `npm run create-component`.