### PR TITLE
feat: routing method with query params

### DIFF
--- a/dadi/frontend/actions/routerActions.js
+++ b/dadi/frontend/actions/routerActions.js
@@ -1,8 +1,9 @@
 import * as Types from 'actions/actionTypes'
 
-export function locationChange(payload) {
+export function locationChange(locationBeforeTransitions, params) {
   return {
     type: Types.LOCATION_CHANGE,
-    payload
+    locationBeforeTransitions,
+    params
   }
 }

--- a/dadi/frontend/lib/router.js
+++ b/dadi/frontend/lib/router.js
@@ -1,0 +1,22 @@
+'use strict'
+
+import {route} from 'preact-router'
+import {urlHelper} from 'lib/util'
+
+export function router({path=window.location.pathname, params=null, update=false}) {
+  let newParams
+
+  if (params) {
+    if (update) {
+      let currentParams = urlHelper().paramsToObject(window.location.search)
+      newParams = urlHelper().paramsToString(Object.assign({}, currentParams, params))
+    } else {
+      newParams = urlHelper().paramsToString(params)
+    }
+  }
+
+  route(`${path}${decodeURIComponent(newParams) || ''}`)
+  return {
+
+  }
+}

--- a/dadi/frontend/lib/router.js
+++ b/dadi/frontend/lib/router.js
@@ -16,7 +16,4 @@ export function router({path=window.location.pathname, params=null, update=false
   }
 
   route(`${path}${decodeURIComponent(newParams) || ''}`)
-  return {
-
-  }
 }

--- a/dadi/frontend/lib/util.js
+++ b/dadi/frontend/lib/util.js
@@ -34,6 +34,38 @@ export function getUniqueId() {
   return `${ID_PREFIX}-${lastId++}`
 }
 
+export function urlHelper() {
+
+  return {
+    paramsToObject(source) {
+      if (!source || typeof source === 'undefined') return null
+      let params = JSON.parse('{"' + decodeURI(source.replace(/^(\?)/,'')).replace(/"/g, '\\"').replace(/&/g, '","').replace(/=/g,'":"') + '"}')
+      Object.keys(params).forEach(param => {
+        try {
+          params[param] = JSON.parse(params[param])
+        } catch (e) {
+          return
+        }
+      })
+
+      return params
+    },
+    paramsToString(params) {
+      return '?' + Object.keys(params).map(key => {
+        if (typeof params[key] === 'object') {
+          try {
+            return key + "=" + JSON.stringify(params[key])
+          } catch (e) {
+            return key + "=" + params[key]
+          }
+        } else {
+          return key + "=" + params[key]
+        }
+      }).join('&')
+    }
+  }
+}
+
 // Object and Field validation
 export function isValidJSON(string) {
   if (!string || typeof string !== 'string') return

--- a/dadi/frontend/middleware/router.js
+++ b/dadi/frontend/middleware/router.js
@@ -26,7 +26,6 @@ export default function syncRouteWithStore(history, store, {
   }
 
   const handleLocationChange = (location) => {
-    console.log("handleLocationChange")
     if (isTimeTraveling) {
       return
     }
@@ -52,11 +51,12 @@ export default function syncRouteWithStore(history, store, {
 
   const handleStoreChange = () => {
     const locationInStore = getLocationInStore(true)
+    
     if (!locationInStore || Object.is(locationInStore, currentLocation || initialLocation)) {
       return
     }
     isTimeTraveling = true
-    // history.push(locationInStore)
+    history.push(locationInStore)
     isTimeTraveling = false
   }
 

--- a/dadi/frontend/middleware/router.js
+++ b/dadi/frontend/middleware/router.js
@@ -1,6 +1,7 @@
 'use strict'
 
 import * as Types from 'actions/actionTypes'
+import {urlHelper} from 'lib/util'
 
 const defaultSelectLocationState = state => state.router
 
@@ -25,6 +26,7 @@ export default function syncRouteWithStore(history, store, {
   }
 
   const handleLocationChange = (location) => {
+    console.log("handleLocationChange")
     if (isTimeTraveling) {
       return
     }
@@ -38,10 +40,13 @@ export default function syncRouteWithStore(history, store, {
       }
     }
 
+    let params = urlHelper().paramsToObject(history.location.search)
+
     // Update the store by calling action
     store.dispatch({
       type: Types.LOCATION_CHANGE,
-      payload: history.location
+      locationBeforeTransitions: history.location,
+      params
     })
   }
 
@@ -51,7 +56,7 @@ export default function syncRouteWithStore(history, store, {
       return
     }
     isTimeTraveling = true
-    history.push(locationInStore)
+    // history.push(locationInStore)
     isTimeTraveling = false
   }
 

--- a/dadi/frontend/reducers/router.js
+++ b/dadi/frontend/reducers/router.js
@@ -3,15 +3,17 @@
 import * as types from 'actions/actionTypes'
 
 const initialState = {
-  locationBeforeTransitions: null
+  locationBeforeTransitions: null,
+  params: null
 }
 
-export default function router(state = initialState, {type, payload} = {}) {
+export default function router(state = initialState, {type, locationBeforeTransitions, params} = {}) {
   switch (type) {
     case types.LOCATION_CHANGE:
       return {
         ...state,
-        locationBeforeTransitions: payload
+        locationBeforeTransitions: locationBeforeTransitions,
+        params : params || null
       }
     default:
       return state

--- a/dadi/frontend/views/DocumentList/DocumentList.jsx
+++ b/dadi/frontend/views/DocumentList/DocumentList.jsx
@@ -172,7 +172,7 @@ class DocumentList extends Component {
   updateUrlParams (filters) {
     const {actions, state} = this.props
     // Replace same with `filters`
-    router({params: {filter: {email: 'am@dadi.co'}}, update: true})
+    
   }
 }
 

--- a/dadi/frontend/views/DocumentList/DocumentList.jsx
+++ b/dadi/frontend/views/DocumentList/DocumentList.jsx
@@ -8,6 +8,7 @@ import * as documentsActions from 'actions/documentsActions'
 import {connectHelper, isValidJSON} from 'lib/util'
 import * as Constants from 'lib/constants'
 import {Keyboard} from 'lib/keyboard'
+import {router} from 'lib/router'
 import APIBridge from 'lib/api-bridge-client'
 
 import DocumentFilters from 'components/DocumentFilters/DocumentFilters'
@@ -164,13 +165,14 @@ class DocumentList extends Component {
       actions.setDocumentList(docs, collection)
     }).catch((err) => {
       actions.clearDocumentList()
-
       // TODO: Graceful deal with failure
     })
   }
 
   updateUrlParams (filters) {
-    // {!} TO-DO update url filters
+    const {actions, state} = this.props
+    // Replace same with `filters`
+    router({params: {filter: {email: 'am@dadi.co'}}, update: true})
   }
 }
 

--- a/dadi/frontend/views/DocumentList/DocumentList.jsx
+++ b/dadi/frontend/views/DocumentList/DocumentList.jsx
@@ -171,8 +171,9 @@ class DocumentList extends Component {
 
   updateUrlParams (filters) {
     const {actions, state} = this.props
-    // Replace same with `filters`
     
+    // Replace same with `filters`
+    router({params: {filter: {email: 'am@dadi.co'}}, update: true})
   }
 }
 


### PR DESCRIPTION
This PR addresses the lack of support for query parameter changing with `preact-router`. 

Using the `router` method from `lib/router` you can now call basic routes as before, as well as update or override url parameters.

### Update 

```javascript

// Basic route change
router({path: '/'})

// Change parameters
// Note that path will default to `window.location.pathname`
router({params: {foo: "bar"}})

// Append existing parameters with `Object.assign`
router({params: {foo: "bar", update: true}})

// Clear all parameters in the current route (not that useful)
router()
```

The other minor change is that now `state.router` has an extra parameter, `params`. This stores an Object of the query parameters:

```javascript
{
  foo: "bar",
  filters: {
    email: "publish_wizard@dadi.co"
  }
}
```