### PR TITLE
Additional field types and support for multiple APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,7 @@ node_modules/
 build/
 log/
 
-config/config.development.json
-config/config.test.json
-config/config.production.json
+config/config.*.json
 
 .wallet
 .tmp

--- a/docs/components/Checkbox.md
+++ b/docs/components/Checkbox.md
@@ -1,0 +1,21 @@
+`Checkbox`
+==========
+
+A checkbox input element.
+
+Props
+-----
+
+### `id`
+
+The ID of the input element.
+
+- type: `string`
+
+
+### `value`
+
+The value of the checkbox, determining whether it's checked or not.
+
+- type: `bool`
+

--- a/docs/components/ElapsedTime.md
+++ b/docs/components/ElapsedTime.md
@@ -1,0 +1,14 @@
+`ElapsedTime`
+=============
+
+The time elapsed since a given event, as an automatically updated string.
+
+Props
+-----
+
+### `timestamp`
+
+The timestamp of the event (in seconds).
+
+- type: `number`
+

--- a/docs/components/FieldBoolean.md
+++ b/docs/components/FieldBoolean.md
@@ -6,37 +6,6 @@ Component for API fields of type String
 Props
 -----
 
-### `error`
-
-Whether the field contains a validation error.
-
-- type: `bool`
-- default value: `false`
-
-
-### `forceValidation`
-
-If true, validation will be executed immediately and not only when the
-content of the field has changed.
-
-- type: `bool`
-- default value: `false`
-
-
-### `onChange`
-
-Callback to be executed when there is a change in the value of the field.
-
-- type: `func`
-
-
-### `onError`
-
-Callback to be executed when there is a new validation error in the field.
-
-- type: `func`
-
-
 ### `schema`
 
 The field schema.
@@ -48,6 +17,6 @@ The field schema.
 
 The field value.
 
-- type: `string`
-- default value: `''`
+- type: `bool`
+- default value: `false`
 

--- a/docs/components/FieldBoolean.md
+++ b/docs/components/FieldBoolean.md
@@ -1,7 +1,7 @@
 `FieldBoolean`
 ==============
 
-Component for API fields of type String
+Component for API fields of type Boolean.
 
 Props
 -----

--- a/docs/components/FieldBoolean.md
+++ b/docs/components/FieldBoolean.md
@@ -1,0 +1,53 @@
+`FieldBoolean`
+==============
+
+Component for API fields of type String
+
+Props
+-----
+
+### `error`
+
+Whether the field contains a validation error.
+
+- type: `bool`
+- default value: `false`
+
+
+### `forceValidation`
+
+If true, validation will be executed immediately and not only when the
+content of the field has changed.
+
+- type: `bool`
+- default value: `false`
+
+
+### `onChange`
+
+Callback to be executed when there is a change in the value of the field.
+
+- type: `func`
+
+
+### `onError`
+
+Callback to be executed when there is a new validation error in the field.
+
+- type: `func`
+
+
+### `schema`
+
+The field schema.
+
+- type: `object`
+
+
+### `value`
+
+The field value.
+
+- type: `string`
+- default value: `''`
+

--- a/docs/components/Label.md
+++ b/docs/components/Label.md
@@ -15,9 +15,18 @@ The input element to be rendered inside the label.
 
 ### `comment`
 
-The text to be rendered on the top-right corner of the label
+The text to be rendered on the top-right corner of the label.
 
 - type: `string`
+
+
+### `compact`
+
+Whether the label is in compact mode, which will render the label text
+and the children on the same line.
+
+- type: `bool`
+- default value: `false`
 
 
 ### `error`

--- a/frontend/actions/documentActions.js
+++ b/frontend/actions/documentActions.js
@@ -1,9 +1,8 @@
 import * as Types from 'actions/actionTypes'
 
-export function setRemoteDocument(document, currentCollection) {
+export function setRemoteDocument(document) {
   return {
     type: Types.SET_REMOTE_DOCUMENT,
-    currentCollection,
     document
   }
 }

--- a/frontend/actions/documentsActions.js
+++ b/frontend/actions/documentsActions.js
@@ -1,10 +1,9 @@
 import * as Types from 'actions/actionTypes'
 
-export function setDocumentList(documents, currentCollection) {
+export function setDocumentList(documents) {
   return {
     type: Types.SET_DOCUMENT_LIST,
-    documents,
-    currentCollection
+    documents
   }
 }
 

--- a/frontend/components/Checkbox/Checkbox.css
+++ b/frontend/components/Checkbox/Checkbox.css
@@ -1,0 +1,61 @@
+.checkbox {
+  outline: none;
+  position: relative;
+  cursor: pointer;
+  text-indent: 30px;
+  margin: 5px 3px;
+  vertical-align: middle;
+  border-radius: 16px;
+  width: 26px;
+  height: 16px;
+  appearance: none;
+}
+
+.checkbox:before {
+  content: ' ';
+  opacity: 1;
+  width: 26px;
+  height: 16px;
+  display: block;
+  background-color: #AAAAAA;
+  user-select: none;
+  tap-highlight-color: transparent;
+  border-radius: 16px;
+  box-shadow: 0 0 0 2px #AAAAAA;
+}
+
+.checkbox:after {
+  content: ' ';
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: block;
+  width: 16px;
+  height: 16px;
+  background-color: #FFFFFF;
+  border-radius: 100%;
+  transition: all 0.2s ease-out;
+}
+
+.checkbox:hover:before,
+.checkbox:focus:before {
+  background-color: #b7b7b7;
+}
+
+.checkbox:checked:before {
+  background-color: #88c24c;
+  box-shadow: 0 0 0 2px #88c24c;
+}
+
+.checkbox:checked:hover:before {
+  background-color: #95c85f;
+}
+
+.checkbox:checked:focus:before {
+  background-color: #7bb63e;
+}
+
+.checkbox:checked:after {
+  left: 100%;
+  margin-left: -16px;
+}

--- a/frontend/components/Checkbox/Checkbox.jsx
+++ b/frontend/components/Checkbox/Checkbox.jsx
@@ -1,0 +1,37 @@
+'use strict'
+
+import {h, Component} from 'preact'
+import proptypes from 'proptypes'
+
+import Style from 'lib/Style'
+import styles from './Checkbox.css'
+
+/**
+ * A checkbox input element.
+ */
+export default class Checkbox extends Component {
+  static propTypes = {
+    /**
+     * The ID of the input element.
+     */
+    id: proptypes.string,
+
+    /**
+     * The value of the checkbox, determining whether it's checked or not.
+     */
+    value: proptypes.bool
+  }
+
+  render() {
+    const {id, value} = this.props
+
+    return (
+      <input
+        checked={value}
+        class={styles.checkbox}
+        id={id}
+        type="checkbox"
+      />
+    )
+  }
+}

--- a/frontend/components/Dropdown/Dropdown.css
+++ b/frontend/components/Dropdown/Dropdown.css
@@ -39,7 +39,11 @@
   text-decoration: none;
 }
 
-.item:hover,
+.item:hover {
+  background-color: var(--theme-colour-background-shade-3, #EEEEEE);
+  color: var(--theme-colour-primary, #000000);
+}
+
 .item-active {
   background-color: var(--theme-colour-data, #4A91FF);
   color: var(--theme-colour-secondary, #ffffff);

--- a/frontend/components/ElapsedTime/ElapsedTime.jsx
+++ b/frontend/components/ElapsedTime/ElapsedTime.jsx
@@ -1,0 +1,80 @@
+'use strict'
+
+import {h, Component} from 'preact'
+import proptypes from 'proptypes'
+
+/**
+ * The time elapsed since a given event, as an automatically updated string.
+ */
+export default class ElapsedTime extends Component {
+  static propTypes = {
+    /**
+     * The timestamp of the event (in seconds).
+     */
+    timestamp: proptypes.number
+  }
+
+  constructor(props) {
+    super(props)
+
+    this.INTERVAL_STRINGS = {
+      0: 'Just now',
+      11: 'Less than a minute ago',
+      61: 'Over a minute ago'
+    }
+
+    this.timer = null
+
+    this.state.activeInterval = null
+  }
+
+  checkInterval() {
+    const {timestamp} = this.props
+    const currentTimestamp = Math.floor(new Date().getTime() / 1000)
+    const timeDifference = Math.max(currentTimestamp - timestamp, 0)
+    const intervals = Object.keys(this.INTERVAL_STRINGS)
+
+    let interval = intervals[0]
+
+    for (let key in this.INTERVAL_STRINGS) {
+      const intervalInt = parseInt(key)
+
+      if (intervalInt > timeDifference) {
+        return this.updateInterval(interval, intervalInt - timeDifference)
+      }
+
+      interval = key
+    }
+
+    return this.updateInterval(intervals[intervals.length - 1], null)
+  }
+
+  updateInterval(interval, nextInterval) {
+    this.setState({
+      activeInterval: interval
+    })
+
+    if (nextInterval) {
+      clearTimeout(this.timer)
+
+      this.timer = setTimeout(this.checkInterval.bind(this), nextInterval * 1000)
+    }
+  }
+
+  componentWillMount() {
+    this.checkInterval()
+  }
+
+  componentWillUpdate() {
+    this.checkInterval()
+  }
+
+  render() {
+    const {timestamp} = this.props
+    const {activeInterval} = this.state
+
+    if (!timestamp || !activeInterval) return null
+
+    return this.INTERVAL_STRINGS[activeInterval]
+  }
+}

--- a/frontend/components/FieldBoolean/FieldBoolean.jsx
+++ b/frontend/components/FieldBoolean/FieldBoolean.jsx
@@ -7,7 +7,7 @@ import Checkbox from 'components/Checkbox/Checkbox'
 import Label from 'components/Label/Label'
 
 /**
- * Component for API fields of type String
+ * Component for API fields of type Boolean.
  */
 export default class FieldBoolean extends Component {
   static propTypes = {

--- a/frontend/components/FieldBoolean/FieldBoolean.jsx
+++ b/frontend/components/FieldBoolean/FieldBoolean.jsx
@@ -1,0 +1,149 @@
+'use strict'
+
+import {h, Component} from 'preact'
+import proptypes from 'proptypes'
+
+import Checkbox from 'components/Checkbox/Checkbox'
+import Label from 'components/Label/Label'
+
+/**
+ * Component for API fields of type String
+ */
+export default class FieldBoolean extends Component {
+  static propTypes = {
+    /**
+     * Whether the field contains a validation error.
+     */
+    error: proptypes.bool,
+
+    /**
+     * If true, validation will be executed immediately and not only when the
+     * content of the field has changed.
+     */
+    forceValidation: proptypes.bool,
+
+    /**
+     * Callback to be executed when there is a change in the value of the field.
+     */
+    onChange: proptypes.func,
+
+    /**
+     * Callback to be executed when there is a new validation error in the field.
+     */
+    onError: proptypes.func,
+
+    /**
+     * The field value.
+     */
+    value: proptypes.string,
+
+    /**
+     * The field schema.
+     */
+    schema: proptypes.object
+  }
+
+  static defaultProps = {
+    error: false,
+    forceValidation: false,
+    value: ''
+  }
+
+  // componentDidMount() {
+  //   const {forceValidation, value} = this.props
+
+  //   if (forceValidation) {
+  //     this.validate(value)
+  //   }
+  // }
+
+  // componentDidUpdate() {
+  //   const {forceValidation, value} = this.props
+
+  //   if (forceValidation) {
+  //     this.validate(value)
+  //   }
+  // }
+
+  render() {
+    const {error, value, schema} = this.props
+    const publishBlock = schema.publish || {}
+
+    return (
+      <Label
+        compact={true}
+        error={error}
+        errorMessage={typeof error === 'string' ? error : null}
+        label={schema.label}
+      >
+        <Checkbox value={value} />
+      </Label>
+    )
+  }
+
+  // handleOnChange(event) {
+  //   const {onChange, schema} = this.props
+
+  //   if (typeof onChange === 'function') {
+  //     onChange.call(this, schema._id, event.target.value)
+  //   }
+  // }
+
+  // validate(value) {
+  //   const {error, onError, schema} = this.props
+  //   const validation = schema && schema.validation
+  //   const valueLength = typeof value === 'string' ? value.length : 0
+
+  //   let validationMessage = typeof schema.message === 'string' && schema.message.length ? schema.message : null
+
+  //   // As per API docs, validation messages are in the format "must be xxx", which
+  //   // assumes that something (probably the name of the field) will be prepended to
+  //   // the string to form a final error message. For this reason, we're prepending
+  //   // the validation message with "This field", but this is something that we can
+  //   // easily revisit.
+  //   if (validationMessage) {
+  //     validationMessage = 'This field ' + validationMessage
+  //   }
+
+  //   let hasErrorsAfterValidation = false
+
+  //   // If the field is required, we add a minLength validation rule,
+  //   // if there isn't one already.
+  //   if (schema.required && !validation.minLength) {
+  //     validation.minLength = 1
+  //   }
+
+  //   if (validation) {
+  //     Object.keys(validation).forEach(validationRule => {
+  //       switch (validationRule) {
+  //         case 'minLength':
+  //           if (valueLength < validation.minLength) {
+  //             hasErrorsAfterValidation = validationMessage && !schema.required ? validationMessage : true
+  //           }
+
+  //           break
+
+  //         case 'maxLength':
+  //           if (valueLength > validation.maxLength) {
+  //             hasErrorsAfterValidation = validationMessage || true
+  //           }
+
+  //           break
+
+  //         case 'regex':
+  //           const regex = new RegExp(validation.regex.pattern, validation.regex.flags)
+
+  //           if (!regex.test(value)) {
+  //             hasErrorsAfterValidation = validationMessage || true
+  //           }
+
+  //           break
+  //       }
+  //     })
+  //   }
+
+  //   if (typeof onError === 'function') {
+  //     onError.call(this, schema._id, hasErrorsAfterValidation, value)
+  //   }
+  // }
+}

--- a/frontend/components/FieldBoolean/FieldBoolean.jsx
+++ b/frontend/components/FieldBoolean/FieldBoolean.jsx
@@ -12,30 +12,9 @@ import Label from 'components/Label/Label'
 export default class FieldBoolean extends Component {
   static propTypes = {
     /**
-     * Whether the field contains a validation error.
-     */
-    error: proptypes.bool,
-
-    /**
-     * If true, validation will be executed immediately and not only when the
-     * content of the field has changed.
-     */
-    forceValidation: proptypes.bool,
-
-    /**
-     * Callback to be executed when there is a change in the value of the field.
-     */
-    onChange: proptypes.func,
-
-    /**
-     * Callback to be executed when there is a new validation error in the field.
-     */
-    onError: proptypes.func,
-
-    /**
      * The field value.
      */
-    value: proptypes.string,
+    value: proptypes.bool,
 
     /**
      * The field schema.
@@ -44,106 +23,19 @@ export default class FieldBoolean extends Component {
   }
 
   static defaultProps = {
-    error: false,
-    forceValidation: false,
-    value: ''
+    value: false
   }
 
-  // componentDidMount() {
-  //   const {forceValidation, value} = this.props
-
-  //   if (forceValidation) {
-  //     this.validate(value)
-  //   }
-  // }
-
-  // componentDidUpdate() {
-  //   const {forceValidation, value} = this.props
-
-  //   if (forceValidation) {
-  //     this.validate(value)
-  //   }
-  // }
-
   render() {
-    const {error, value, schema} = this.props
-    const publishBlock = schema.publish || {}
+    const {value, schema} = this.props
 
     return (
       <Label
         compact={true}
-        error={error}
-        errorMessage={typeof error === 'string' ? error : null}
         label={schema.label}
       >
         <Checkbox value={value} />
       </Label>
     )
   }
-
-  // handleOnChange(event) {
-  //   const {onChange, schema} = this.props
-
-  //   if (typeof onChange === 'function') {
-  //     onChange.call(this, schema._id, event.target.value)
-  //   }
-  // }
-
-  // validate(value) {
-  //   const {error, onError, schema} = this.props
-  //   const validation = schema && schema.validation
-  //   const valueLength = typeof value === 'string' ? value.length : 0
-
-  //   let validationMessage = typeof schema.message === 'string' && schema.message.length ? schema.message : null
-
-  //   // As per API docs, validation messages are in the format "must be xxx", which
-  //   // assumes that something (probably the name of the field) will be prepended to
-  //   // the string to form a final error message. For this reason, we're prepending
-  //   // the validation message with "This field", but this is something that we can
-  //   // easily revisit.
-  //   if (validationMessage) {
-  //     validationMessage = 'This field ' + validationMessage
-  //   }
-
-  //   let hasErrorsAfterValidation = false
-
-  //   // If the field is required, we add a minLength validation rule,
-  //   // if there isn't one already.
-  //   if (schema.required && !validation.minLength) {
-  //     validation.minLength = 1
-  //   }
-
-  //   if (validation) {
-  //     Object.keys(validation).forEach(validationRule => {
-  //       switch (validationRule) {
-  //         case 'minLength':
-  //           if (valueLength < validation.minLength) {
-  //             hasErrorsAfterValidation = validationMessage && !schema.required ? validationMessage : true
-  //           }
-
-  //           break
-
-  //         case 'maxLength':
-  //           if (valueLength > validation.maxLength) {
-  //             hasErrorsAfterValidation = validationMessage || true
-  //           }
-
-  //           break
-
-  //         case 'regex':
-  //           const regex = new RegExp(validation.regex.pattern, validation.regex.flags)
-
-  //           if (!regex.test(value)) {
-  //             hasErrorsAfterValidation = validationMessage || true
-  //           }
-
-  //           break
-  //       }
-  //     })
-  //   }
-
-  //   if (typeof onError === 'function') {
-  //     onError.call(this, schema._id, hasErrorsAfterValidation, value)
-  //   }
-  // }
 }

--- a/frontend/components/FieldString/FieldString.css
+++ b/frontend/components/FieldString/FieldString.css
@@ -9,7 +9,6 @@
   border: 1px solid #e4e4e4;
   border-radius: 5px;
   outline: 0;
-  padding-top: 6px;
 }
 
 .dropdown[multiple] {
@@ -23,4 +22,8 @@
 
 .dropdown-option {
   padding: 3px 10px;
+}
+
+.dropdown-option:first-of-type {
+  padding-top: 6px;
 }

--- a/frontend/components/FieldString/FieldString.css
+++ b/frontend/components/FieldString/FieldString.css
@@ -1,3 +1,26 @@
-.field {
-  margin-bottom: 20px;
+.dropdown {
+  font-family: var(--theme-font-family, sans-serif);
+  width: 100%;
+  margin-top: 9px;
+  height: 25px;
+  line-height: 25px;
+  font-size: 15px;
+  box-sizing: border-box;
+  border: 1px solid #e4e4e4;
+  border-radius: 5px;
+  outline: 0;
+  padding-top: 6px;
+}
+
+.dropdown[multiple] {
+  background-color: #fafafa;
+  height: 170px;
+}
+
+.dropdown-error[multiple] {
+  background-color: inherit;
+}
+
+.dropdown-option {
+  padding: 3px 10px;
 }

--- a/frontend/components/FieldString/FieldString.jsx
+++ b/frontend/components/FieldString/FieldString.jsx
@@ -116,26 +116,38 @@ export default class FieldString extends Component {
           class={dropdownStyle.getClasses()}
           onChange={this.handleOnChange.bind(this)}
           multiple={multiple}
+          ref={multiple && this.selectDropdownOptions.bind(this)}
+          value={selectedValue}
         >
-          <option
-            class={styles['dropdown-option']}
-            disabled
-            selected={selectedValue === null}
-            style={multiple ? 'display: none;' : ''}
-          >Please select</option>
+          {!multiple &&
+            <option
+              class={styles['dropdown-option']}
+              disabled
+              selected={selectedValue === null}
+            >Please select</option>
+          }
 
           {options.map(option => {
             return (
               <option
                 class={styles['dropdown-option']}
                 value={option.value}
-                selected={option.value === selectedValue}
               >{option.label}</option>
             )
           })}
         </select>
       </Label>
     )
+  }
+
+  selectDropdownOptions(input) {
+    const {value} = this.props
+
+    for (let i = 0; i < input.options.length; i++) {
+      if (value.includes(input.options[i].value)) {
+        input.options[i].selected = true
+      }
+    }
   }
 
   render() {

--- a/frontend/components/FieldString/FieldString.jsx
+++ b/frontend/components/FieldString/FieldString.jsx
@@ -73,45 +73,119 @@ export default class FieldString extends Component {
     }
   }
 
-  render() {
+  renderAsFreeInput() {
     const {error, value, schema} = this.props
     const publishBlock = schema.publish || {}
     const type = publishBlock.multiline ? 'multiline' : 'text'
 
     return (
-      <div class={styles.field}>
-        <Label
-          error={error}
-          errorMessage={typeof error === 'string' ? error : null}
-          label={schema.label}
-          comment={schema.required ? 'Required' : 'Optional'}
-        >
-          <TextInput
-            onChange={this.handleOnChange.bind(this)}
-            onKeyUp={this.handleOnKeyUp.bind(this)}
-            type={type}
-            value={value}
-          />
-        </Label>
-      </div>
+      <Label
+        error={error}
+        errorMessage={typeof error === 'string' ? error : null}
+        label={schema.label}
+        comment={schema.required ? 'Required' : 'Optional'}
+      >
+        <TextInput
+          onChange={this.handleOnChange.bind(this)}
+          onKeyUp={this.handleOnKeyUp.bind(this)}
+          type={type}
+          value={value}
+        />
+      </Label>
     )
+  }
+
+  renderAsDropdown() {
+    const {error, value, schema} = this.props
+    const publishBlock = schema.publish || {}
+    const options = publishBlock.options
+    const selectedValue = value || schema.default || null
+    const multiple = publishBlock.multiple === true
+    const dropdownStyle = new Style(styles, 'dropdown')
+
+    dropdownStyle.addIf('dropdown-error', error)
+
+    return (
+      <Label
+        error={error}
+        errorMessage={typeof error === 'string' ? error : null}
+        label={schema.label}
+        comment={schema.required ? 'Required' : 'Optional'}
+      >
+        <select
+          class={dropdownStyle.getClasses()}
+          onChange={this.handleOnChange.bind(this)}
+          multiple={multiple}
+        >
+          <option
+            class={styles['dropdown-option']}
+            disabled
+            selected={selectedValue === null}
+            style={multiple ? 'display: none;' : ''}
+          >Please select</option>
+
+          {options.map(option => {
+            return (
+              <option
+                class={styles['dropdown-option']}
+                value={option.value}
+                selected={option.value === selectedValue}
+              >{option.label}</option>
+            )
+          })}
+        </select>
+      </Label>
+    )
+  }
+
+  render() {
+    const {schema} = this.props
+    const publishBlock = schema.publish || {}
+
+    if (publishBlock.options) {
+      return this.renderAsDropdown()
+    }
+
+    return this.renderAsFreeInput()
+  }
+
+  getValueOfInput(input) {
+    switch (input.nodeName.toUpperCase()) {
+      case 'SELECT':
+        const options = Array.prototype.slice.call(input.options)
+        const value = options.filter(option => option.selected).map(option => option.value)
+
+        // If this isn't a multiple value select, we want to return the selected
+        // value as a single element and not wrapped in a one-element array.
+        if (!input.attributes.multiple) {
+          return value[0]
+        }
+
+        return value
+
+      default:
+        return input.value
+    }
   }
 
   handleOnChange(event) {
     const {onChange, schema} = this.props
+    const value = this.getValueOfInput(event.target)
 
     if (typeof onChange === 'function') {
-      onChange.call(this, schema._id, event.target.value)
+      onChange.call(this, schema._id, value)
     }
   }
 
   handleOnKeyUp(event) {
-    this.validate(event.target.value)
+    const value = this.getValueOfInput(event.target)
+
+    this.validate(value)
   }
 
-  validate(value) {
-    const {error, onError, schema} = this.props
-    const validation = schema && schema.validation
+  findValidationErrorsInString(value) {
+    const {error, schema} = this.props
+    const validation = (schema && schema.validation) || {}
     const valueLength = typeof value === 'string' ? value.length : 0
 
     let validationMessage = typeof schema.message === 'string' && schema.message.length ? schema.message : null
@@ -125,27 +199,21 @@ export default class FieldString extends Component {
       validationMessage = 'This field ' + validationMessage
     }
 
-    let hasErrorsAfterValidation = false
-
-    // If the field is required, we add a minLength validation rule,
-    // if there isn't one already.
-    if (schema.required && !validation.minLength) {
-      validation.minLength = 1
-    }
+    let hasValidationErrors = false
 
     if (validation) {
       Object.keys(validation).forEach(validationRule => {
         switch (validationRule) {
           case 'minLength':
             if (valueLength < validation.minLength) {
-              hasErrorsAfterValidation = validationMessage && !schema.required ? validationMessage : true
+              hasValidationErrors = validationMessage || true
             }
 
             break
 
           case 'maxLength':
             if (valueLength > validation.maxLength) {
-              hasErrorsAfterValidation = validationMessage || true
+              hasValidationErrors = validationMessage || true
             }
 
             break
@@ -154,7 +222,7 @@ export default class FieldString extends Component {
             const regex = new RegExp(validation.regex.pattern, validation.regex.flags)
 
             if (!regex.test(value)) {
-              hasErrorsAfterValidation = validationMessage || true
+              hasValidationErrors = validationMessage || true
             }
 
             break
@@ -162,8 +230,43 @@ export default class FieldString extends Component {
       })
     }
 
+    return hasValidationErrors
+  }
+
+  validate(value) {
+    const {onError, schema} = this.props
+
+    let hasValidationErrors = false
+
+    // Are we dealing with multiple values?
+    if (value instanceof Array) {
+      // If the field is required and we don't have any values selected,
+      // there's a validation error.
+      hasValidationErrors = schema.required && (value.length === 0)
+
+      // If there are no errors so far, we proceed to validate each value
+      // in the array as an individual string to check for other validation
+      // parameters.
+      if (!hasValidationErrors) {
+        const individualValidationErrors = value.filter(valueString => {
+          return this.findValidationErrorsInString(valueString)
+        })
+
+        hasValidationErrors = individualValidationErrors[0] || false
+      }
+    } else {
+      const trimmedValue = typeof value === 'string' ? value.trim() : ''
+
+      // If the field is required and its value is empty, there's a validation
+      // error.
+      hasValidationErrors = schema.required && (trimmedValue.length === 0)
+
+      // We then proceed to validate the value for other validation parameters.
+      hasValidationErrors = hasValidationErrors || this.findValidationErrorsInString(trimmedValue)
+    }
+
     if (typeof onError === 'function') {
-      onError.call(this, schema._id, hasErrorsAfterValidation, value)
+      onError.call(this, schema._id, hasValidationErrors, value)
     }
   }
 }

--- a/frontend/components/Label/Label.css
+++ b/frontend/components/Label/Label.css
@@ -10,6 +10,16 @@
   color: var(--theme-colour-primary-shade-1, #FAFAFA);
 }
 
+.container-compact {
+  display: flex;
+  align-items: center;
+  padding: 15px 13px;
+}
+
+.container-compact.container-with-comment {
+  padding: 15px 80px 15px 13px;
+}
+
 .container-error {
   background-color: #fef8f8;
   box-shadow: 2px 2px 10px 0 rgba(255, 46, 46, 0.23);
@@ -20,7 +30,12 @@
   border-top-left-radius: 0;
 }
 
-.label {
+.container-compact .label {
+  font-size: 15px;
+  margin-left: 10px;
+}
+
+.container:not(.container-compact) .label {
   position: absolute;
   top: 13px;
   left: 14px;
@@ -31,6 +46,11 @@
   position: absolute;
   top: 13px;
   right: 14px;
+}
+
+.container-compact .comment {
+  top: 50%;
+  transform: translateY(-50%);
 }
 
 .error-message {

--- a/frontend/components/Label/Label.jsx
+++ b/frontend/components/Label/Label.jsx
@@ -14,9 +14,15 @@ import styles from './Label.css'
 export default class Label extends Component {
   static propTypes = {
     /**
-     * The text to be rendered on the top-right corner of the label
+     * The text to be rendered on the top-right corner of the label.
      */
     comment: proptypes.string,
+
+    /**
+     * Whether the label is in compact mode, which will render the label text
+     * and the children on the same line.
+     */
+    compact: proptypes.bool,
 
     /**
      * Whether there's an error in the label field.
@@ -40,6 +46,7 @@ export default class Label extends Component {
   }
 
   static defaultProps = {
+    compact: false,
     error: false,
     errorMessage: null,
     optional: false,
@@ -81,15 +88,19 @@ export default class Label extends Component {
   }  
 
   render() {
-    const {comment, error, errorMessage} = this.props
+    const {comment, compact, error, errorMessage} = this.props
 
     let labelStyle = new Style(styles, 'container')
 
+    labelStyle.addIf('container-compact', compact)
+    labelStyle.addIf('container-with-comment', comment)
     labelStyle.addIf('container-error', error)
     labelStyle.addIf('container-error-message', errorMessage)
 
     return (
       <div class={labelStyle.getClasses()}>
+        {this.renderChildren()}
+
         <label
           for={this.id}
           class={styles.label}
@@ -104,8 +115,6 @@ export default class Label extends Component {
         {errorMessage &&
           <p class={styles['error-message']}>{errorMessage}</p>
         }
-
-        {this.renderChildren()}
       </div>
     )
   }

--- a/frontend/components/LoadingBar/LoadingBar.jsx
+++ b/frontend/components/LoadingBar/LoadingBar.jsx
@@ -82,6 +82,7 @@ export default class LoadingBar extends Component {
     })
 
     clearInterval(this.intervalVisible)
+    clearInterval(this.intervalBump)
 
     this.intervalVisible = setTimeout(() => {
       this.setState({

--- a/frontend/lib/app-config.js
+++ b/frontend/lib/app-config.js
@@ -1,12 +1,90 @@
 'use strict'
 
 import 'fetch'
+import {slugify} from 'lib/util'
 
-module.exports = () => {
+/**
+ * Retrieves the app configuration file.
+ *
+ * @return {promise} An object representing the configuration file.
+ */
+export function getAppConfig () {
   return fetch('/config', {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json'
     }
-  }).then(response => response.json())  
+  }).then(response => response.json())
+}
+
+/**
+ * Returns the API to be used given a group and collection name
+ * present in the URL.
+ *
+ * @param {array} apis - The list of available APIs.
+ * @param {string} urlGroup - The group present in the URL.
+ * @param {string} urlCollection - The name of the collection present
+ *                                 in the URL.
+ *
+ * @return {object} The configuration block for the given API.
+ */
+export function getCurrentApi (apis, urlGroup, urlCollection) {
+  // Are we looking at a collection name with a prefix (e.g. 'users-2')?
+  const urlCollectionParts = urlCollection.match(/(.*)-([0-9]+)/)
+  const urlCollectionName = urlCollectionParts ? urlCollectionParts[1] : urlCollection
+  const urlCollectionNumber = urlCollectionParts ? parseInt(urlCollectionParts[2]) : 1
+
+  let matchesFound = 0
+
+  const api = apis.find(api => {
+    const collection = api.collections && api.collections.find(collection => {
+      return collection.name === urlCollectionName
+    })
+
+    if (collection) {
+      const group = (api.menu || []).find(menuItem => {
+        return menuItem.collections && menuItem.collections.includes(urlCollectionName)
+      })
+
+      // If there isn't a group in the URL and the candidate collection isn't
+      // inside a group, then it's a match.
+      if (!urlGroup && !group) {
+        return (++matchesFound === urlCollectionNumber)
+      }
+
+      // If there is a group in the URL and that matches the group of the candidate
+      // collection, then it's a match.
+      if (urlGroup && group && (slugify(group.title) === urlGroup)) {
+        return (++matchesFound === urlCollectionNumber)
+      }
+    }
+  })
+
+  return api
+}
+
+/**
+ * Returns the collection to be used given a group and collection name
+ * present in the URL.
+ *
+ * @param {array} apis - The list of available APIs.
+ * @param {string} urlGroup - The group present in the URL.
+ * @param {string} urlCollection - The name of the collection present
+ *                                 in the URL.
+ *
+ * @return {object} The schema for the given collection.
+ */
+export function getCurrentCollection (apis, urlGroup, urlCollection) {
+  const api = getCurrentApi(apis, urlGroup, urlCollection)
+
+  if (!api || !api.collections) return null
+
+  const urlCollectionParts = urlCollection.match(/(.*)-([0-9]+)/)
+  const urlCollectionName = urlCollectionParts ? urlCollectionParts[1] : urlCollection
+
+  const collection = api.collections.find(collection => {
+    return collection.name === urlCollectionName
+  })
+
+  return collection
 }

--- a/frontend/reducers/api.js
+++ b/frontend/reducers/api.js
@@ -5,7 +5,6 @@ import * as Constants from 'lib/constants'
 
 const initialState = {
   apis: [],
-  currentCollection: null,
   status: Constants.STATUS_IDLE
 }
 
@@ -50,29 +49,6 @@ export default function api(state = initialState, action = {}) {
     // Action: user signed out
     case Types.SIGN_OUT:
       return initialState
-
-    // Actions: set document or set document list
-    case Types.SET_REMOTE_DOCUMENT:
-    case Types.SET_DOCUMENT_LIST:
-      if (!action.currentCollection) return state
-
-      let collectionSchema
-
-      // (!) TO DO: This will need to take the group into account
-      state.apis.some(api => {
-        return api.collections && api.collections.some(collection => {
-          if (collection.name === action.currentCollection) {
-            collectionSchema = collection
-
-            return true
-          }
-        })
-      })
-
-      return {
-        ...state,
-        currentCollection: collectionSchema
-      }  
 
     default:
       return state

--- a/frontend/views/DocumentEdit/DocumentEdit.css
+++ b/frontend/views/DocumentEdit/DocumentEdit.css
@@ -1,5 +1,5 @@
 .container {
-  margin: 20px 0 80px 0;
+  padding: 20px 0 80px 0;
 }
 
 .section {
@@ -21,7 +21,7 @@
 }
 
 @media (--breakpoint-medium) {
-  .main {
+  .main:not(.main-full) {
     width: 66.6666%;
     width: calc(2 * (100% / 3));
     padding: 10px 10px 10px 20px;  
@@ -39,4 +39,8 @@
     width: calc(100% / 3);
     padding: 10px 20px 10px 10px;
   }
+}
+
+.field {
+  margin-bottom: 20px;
 }

--- a/frontend/views/DocumentList/DocumentList.jsx
+++ b/frontend/views/DocumentList/DocumentList.jsx
@@ -191,7 +191,7 @@ class DocumentList extends Component {
       actions.setDocumentList(docs, collection)
     }).catch(err => {
       console.log(err)
-      actions.clearDocumentList()
+      //actions.clearDocumentList()
       // {!} TODO: Graceful deal with failure
     })
   }

--- a/frontend/views/DocumentList/DocumentList.jsx
+++ b/frontend/views/DocumentList/DocumentList.jsx
@@ -10,6 +10,7 @@ import * as Constants from 'lib/constants'
 import {Keyboard} from 'lib/keyboard'
 import {router, createRoute, buildUrl} from 'lib/router'
 import APIBridge from 'lib/api-bridge-client'
+import {getCurrentApi, getCurrentCollection} from 'lib/app-config'
 
 import Button from 'components/Button/Button'
 import DocumentFilters from 'components/DocumentFilters/DocumentFilters'
@@ -37,7 +38,7 @@ class DocumentList extends Component {
     } = this.props
     const {filtersVisible} = this.state
     const documents = state.documents
-    const currentCollection = state.api.currentCollection
+    const currentCollection = getCurrentCollection(state.api.apis, group, collection)
 
     if (!documents.list || documents.status === Constants.STATUS_LOADING || !currentCollection) {
       return null
@@ -92,7 +93,7 @@ class DocumentList extends Component {
                 renderCallback={(value, data, column, index) => {
                   if (index === 0) {
                     return (
-                      <a href={buildUrl(group, currentCollection.name, 'document/edit', data._id)}>{value}</a>
+                      <a href={buildUrl(group, collection, 'document/edit', data._id)}>{value}</a>
                     )
                   }
 
@@ -125,8 +126,10 @@ class DocumentList extends Component {
     // State check: reject when missing config, session, or apis
     if (!state.app.config || !state.api.apis.length || !state.user) return
 
-    // Fixed to checking first API, but will eventually need to check all
-    if (!state.api.apis[0].collections || !state.api.apis[0].collections.length > 0) return
+    // State check: reject when there are still APIs without collections
+    const apisWithoutCollections = state.api.apis.filter(api => !api.collections).length
+
+    if (apisWithoutCollections) return
 
     // State check: reject when path matches and document list loaded
     if (list && (newStatePath === previousStatePath) && (newStateSearch === previousStateSearch)) return
@@ -157,6 +160,7 @@ class DocumentList extends Component {
       actions,
       collection,
       filter,
+      group,
       order,
       page,
       sort,
@@ -165,12 +169,14 @@ class DocumentList extends Component {
 
     const sortBy = sort || 'createdAt'
     const sortOrder = order || 'desc'
+    const currentApi = getCurrentApi(state.api.apis, group, collection)
+    const currentCollection = getCurrentCollection(state.api.apis, group, collection)
 
     // Set document loading status to 'Loading'
     actions.setDocumentListStatus(Constants.STATUS_LOADING)
 
-    let query = APIBridge(state.api.apis[0])
-      .in(collection)
+    let query = APIBridge(currentApi)
+      .in(currentCollection.name)
       .limitTo(20) // Config based on collection schema
       .goToPage(page)
       .sortBy(sortBy, sortOrder)
@@ -182,13 +188,8 @@ class DocumentList extends Component {
     }
 
     return query.find().then(docs => {
-      // Filter current collection
-      const currentCollection = state.api.apis[0].collections.find(stateCollection => {
-        return stateCollection.slug === collection
-      })
-
       // Update state with results
-      actions.setDocumentList(docs, collection)
+      actions.setDocumentList(docs)
     }).catch(err => {
       console.log(err)
       //actions.clearDocumentList()


### PR DESCRIPTION
This PR adds:

- Support for `Boolean` API fields (with the `FieldBoolean` component)
- Support for dropdowns (single and multiple) in `FieldString`
- Support for multiple APIs
- Collection nav now uses collection friendly name (`settings.description`) by default and slug as a fallback
- Minor performance fixes to `LoadingBar`