### PR TITLE
Add throttling to API bridge calls

### DIFF
--- a/frontend/lib/api-bridge-client.js
+++ b/frontend/lib/api-bridge-client.js
@@ -14,10 +14,7 @@ let onUpdate = null
 let throttle = null
 
 function throttleAllow() {
-  throttle = throttle || setTimeout(() => {
-    callCount = 0
-    throttle = null
-  }, 1000)
+  throttle = setTimeout(() => callCount = 0, 1000)
 
   return ++callCount <= MAX_CALLS_PER_SECOND
 }

--- a/frontend/lib/api-bridge-client.js
+++ b/frontend/lib/api-bridge-client.js
@@ -14,6 +14,7 @@ let onUpdate = null
 let throttle = null
 
 function throttleAllow() {
+  clearInterval(throttle)
   throttle = setTimeout(() => callCount = 0, 1000)
 
   return ++callCount <= MAX_CALLS_PER_SECOND

--- a/frontend/lib/api-bridge-client.js
+++ b/frontend/lib/api-bridge-client.js
@@ -5,9 +5,28 @@ import * as Constants from 'lib/constants'
 
 const APIWrapper = require('@dadi/api-wrapper-core')
 
+// The maximum number of allowed API calls per second. Any API Bridge calls
+// past this limit will be blocked and the Promise will reject.
+const MAX_CALLS_PER_SECOND = 150
+
+let callCount = 0
 let onUpdate = null
+let throttle = null
+
+function throttleAllow() {
+  throttle = throttle || setTimeout(() => {
+    callCount = 0
+    throttle = null
+  }, 1000)
+
+  return ++callCount <= MAX_CALLS_PER_SECOND
+}
 
 const apiBridgeFetch = function (requestObject) {
+  if (!throttleAllow()) {
+    return Promise.reject('API_CALL_QUOTA_EXCEEDED')
+  }
+
   return fetch('/api', {
     body: JSON.stringify(requestObject),
     credentials: 'same-origin',

--- a/frontend/lib/api-bridge-client.js
+++ b/frontend/lib/api-bridge-client.js
@@ -13,7 +13,7 @@ let callCount = 0
 let onUpdate = null
 let throttle = null
 
-function throttleAllow() {
+function throttleAllow () {
   clearInterval(throttle)
   throttle = setTimeout(() => callCount = 0, 1000)
 


### PR DESCRIPTION
This PR adds throttling to API bridge calls, as per #32. It has a configurable number of maximum calls per second, and every time this limit is exceeded we "close the gate" on requests and only open it again once the flood of requests has stopped for a second.

When the limit is exceeded, API bridge calls return a Promise rejected with `API_CALL_QUOTA_EXCEEDED`.