### PR TITLE
Enforce validation before submit

### DIFF
--- a/frontend/containers/NotificationCentre/NotificationCentre.jsx
+++ b/frontend/containers/NotificationCentre/NotificationCentre.jsx
@@ -26,8 +26,21 @@ class NotificationCentre extends Component {
   constructor(props) {
     super(props)
 
+    this.enqueuedNotification = null
     this.state.visible = false
     this.timeout = null
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const notification = this.props.state.app.notification
+    const nextNotification = nextProps.state.app.notification
+
+    if (notification && nextNotification &&
+        notification.timestamp !== nextNotification.timestamp) {
+      this.enqueuedNotification = notification
+
+      this.dismiss()
+    }
   }
 
   shouldComponentUpdate(nextProps, nextState) {
@@ -38,8 +51,8 @@ class NotificationCentre extends Component {
       return true
     }
 
-    if (notification && nextNotification && 
-       (notification.timestamp === nextNotification.timestamp)) {
+    if (notification && nextNotification &&
+        notification.timestamp === nextNotification.timestamp) {
       return false
     }
   }
@@ -67,16 +80,20 @@ class NotificationCentre extends Component {
       this.start()
     }
 
-    if (prevNotification && notification && 
-       (prevNotification.timestamp !== notification.timestamp)) {
-      this.start()
+    if (prevNotification && notification &&
+        prevNotification.timestamp !== notification.timestamp) {
+      setTimeout(() => {
+        this.enqueuedNotification = null
+
+        this.start()
+      }, 300)
     }
   }
 
   render() {
     const {state} = this.props
     const {visible} = this.state
-    const notification = state.app.notification
+    const notification = this.enqueuedNotification || state.app.notification
 
     if (!notification) return null
 
@@ -120,6 +137,8 @@ class NotificationCentre extends Component {
   }
 
   dismiss() {
+    clearTimeout(this.timeout)
+
     this.setState({
       visible: false
     })

--- a/frontend/reducers/app.js
+++ b/frontend/reducers/app.js
@@ -108,6 +108,17 @@ export default function app (state = initialState, action = {}) {
 
       return state
 
+    // Document action: save document
+    case Types.SAVE_DOCUMENT:
+      if (!action.notification) {
+        return state
+      }
+
+      return {
+        ...state,
+        notification: getNotificationObject(action.notification)
+      }
+
     // App action: set config
     case Types.SET_APP_CONFIG:
       return {
@@ -144,17 +155,6 @@ export default function app (state = initialState, action = {}) {
       return {
         ...state,
         breakpoint
-      }
-
-    // Document action: save document
-    case Types.SAVE_DOCUMENT:
-      if (!action.notification) {
-        return state
-      }
-
-      return {
-        ...state,
-        notification: getNotificationObject(action.notification)
       }
 
     // User action: user signed out

--- a/frontend/reducers/document.js
+++ b/frontend/reducers/document.js
@@ -11,7 +11,7 @@ const initialState = {
   peers: null,
   remote: null,
   remoteStatus: Constants.STATUS_IDLE,
-  validationErrors: {}
+  validationErrors: null
 }
 
 // Boolean fields are a bit special. Any required field that hasn't
@@ -57,7 +57,7 @@ export default function document (state = initialState, action = {}) {
         dirty: false,
         loadedFromLocalStorage: false,
         local: getDocumentWithBooleans(state.remote, action.context.collection),
-        validationErrors: {}
+        validationErrors: null
       }
 
     // Document action: save document
@@ -96,12 +96,13 @@ export default function document (state = initialState, action = {}) {
     case Types.SET_FIELD_ERROR_STATUS:
       const error = action.error || null
       const fieldName = action.field
+      const {validationErrors} = state
 
       // If the validation error status for the field hasn't changed, there's nothing
       // to do here, so we return the current state (avoiding a re-render).
       // Note that the weak comparison (== instead of ===) is on purpose, as we want
       // `null` and `undefined` to evaluate the same way.
-      if (state.validationErrors[fieldName] == error) {
+      if (validationErrors && validationErrors[fieldName] == error) {
         return state
       }
 


### PR DESCRIPTION
This PR addresses the issue outlined in #137. Fields only validate themselves once they have been interacted with OR when the user tries to save the document, and not when the page loads. This is to avoid seeing loads of error messages on the page before the user even starts working on the document.

However, previously we weren't actually blocking the save operation when validation errors occurred. We are now. So if you try to submit the form with a required field missing, the error messages will be flagged and the save button will be disabled.

(Again, sorry for the confusing diff caused by changing the order of functions within the container. As files start getting larger, I find it really helps to have things sorted in a meaningful way.)