### PR TITLE
Add support for multi-document reference fields

### DIFF
--- a/app/lib/controllers/session.js
+++ b/app/lib/controllers/session.js
@@ -21,7 +21,7 @@ Session.prototype.authorise = function (email, password, next) {
         return next(null)
       }
     }).catch(response => {
-      if ((response.error instanceof Array) && (response.error[0].details.includes('WRONG_CREDENTIALS'))) {
+      if (Array.isArray(response.error) && (response.error[0].details.includes('WRONG_CREDENTIALS'))) {
         return next('WRONG_CREDENTIALS')
       }
 

--- a/docs/component-architecture.md
+++ b/docs/component-architecture.md
@@ -1,8 +1,248 @@
 ```
-FieldBoolean
-├─┬ FieldBooleanEdit
-│ ├── Checkbox
-│ └── Label
-└── FieldBooleanList
+App
+├─┬ Header
+│ ├─┬ CollectionNav
+│ │ └─┬ Nav
+│ │   ├── Dropdown
+│ │   ├── DropdownItem
+│ │   └── NavItem
+│ ├── IconBurger
+│ └── IconCross
+├─┬ Main
+│ ├── LoadingBar
+│ └─┬ NotificationCentre
+│   └── Notification
+├─┬ DocumentCreateView
+│ ├─┬ DocumentEdit
+│ │ ├─┬ ErrorMessage
+│ │ │ ├── Button
+│ │ │ └── HeroMessage
+│ │ └── SubNavItem
+│ ├─┬ DocumentEditToolbar
+│ │ ├── Button
+│ │ ├─┬ ButtonWithOptions
+│ │ │ ├── Button
+│ │ │ ├── Dropdown
+│ │ │ ├── DropdownItem
+│ │ │ └── IconArrow
+│ │ ├─┬ ButtonWithPrompt
+│ │ │ ├── Button
+│ │ │ └─┬ Prompt
+│ │ │   └── Button
+│ │ ├── DateTime
+│ │ ├─┬ Peer
+│ │ │ └── Button
+│ │ └── Toolbar
+│ ├─┬ Header
+│ │ ├─┬ CollectionNav
+│ │ │ └─┬ Nav
+│ │ │   ├── Dropdown
+│ │ │   ├── DropdownItem
+│ │ │   └── NavItem
+│ │ ├── IconBurger
+│ │ └── IconCross
+│ ├─┬ Main
+│ │ ├── LoadingBar
+│ │ └─┬ NotificationCentre
+│ │   └── Notification
+│ └── Page
+├─┬ DocumentEditView
+│ ├─┬ DocumentEdit
+│ │ ├─┬ ErrorMessage
+│ │ │ ├── Button
+│ │ │ └── HeroMessage
+│ │ └── SubNavItem
+│ ├─┬ DocumentEditToolbar
+│ │ ├── Button
+│ │ ├─┬ ButtonWithOptions
+│ │ │ ├── Button
+│ │ │ ├── Dropdown
+│ │ │ ├── DropdownItem
+│ │ │ └── IconArrow
+│ │ ├─┬ ButtonWithPrompt
+│ │ │ ├── Button
+│ │ │ └─┬ Prompt
+│ │ │   └── Button
+│ │ ├── DateTime
+│ │ ├─┬ Peer
+│ │ │ └── Button
+│ │ └── Toolbar
+│ ├─┬ Header
+│ │ ├─┬ CollectionNav
+│ │ │ └─┬ Nav
+│ │ │   ├── Dropdown
+│ │ │   ├── DropdownItem
+│ │ │   └── NavItem
+│ │ ├── IconBurger
+│ │ └── IconCross
+│ ├─┬ Main
+│ │ ├── LoadingBar
+│ │ └─┬ NotificationCentre
+│ │   └── Notification
+│ └── Page
+├─┬ DocumentListView
+│ ├─┬ DocumentList
+│ │ ├── Button
+│ │ ├─┬ ErrorMessage
+│ │ │ ├── Button
+│ │ │ └── HeroMessage
+│ │ ├── HeroMessage
+│ │ └─┬ SyncTable
+│ │   ├── Table
+│ │   ├─┬ TableHead
+│ │   │ └─┬ TableHeadCell
+│ │   │   └── IconArrow
+│ │   ├─┬ TableHeadCell
+│ │   │ └── IconArrow
+│ │   ├─┬ TableRow
+│ │   │ └── TableRowCell
+│ │   └── TableRowCell
+│ ├─┬ DocumentListController
+│ │ ├── Button
+│ │ ├─┬ DocumentFilters
+│ │ │ ├─┬ DocumentFilter
+│ │ │ │ ├── TextInput
+│ │ │ │ └── Button
+│ │ │ └── Button
+│ │ └─┬ ListController
+│ │   └─┬ DocumentSearch
+│ │     └── TextInput
+│ ├─┬ DocumentListToolbar
+│ │ ├── Button
+│ │ ├─┬ ButtonWithPrompt
+│ │ │ ├── Button
+│ │ │ └─┬ Prompt
+│ │ │   └── Button
+│ │ ├── Checkbox
+│ │ ├─┬ Paginator
+│ │ │ └── Button
+│ │ ├── Toolbar
+│ │ └─┬ ToolbarTextInput
+│ │   └── TextInput
+│ ├─┬ Header
+│ │ ├─┬ CollectionNav
+│ │ │ └─┬ Nav
+│ │ │   ├── Dropdown
+│ │ │   ├── DropdownItem
+│ │ │   └── NavItem
+│ │ ├── IconBurger
+│ │ └── IconCross
+│ ├─┬ Main
+│ │ ├── LoadingBar
+│ │ └─┬ NotificationCentre
+│ │   └── Notification
+│ ├── Page
+│ └─┬ ReferencedDocumentHeader
+│   └── Button
+├─┬ ErrorView
+│ ├─┬ Header
+│ │ ├─┬ CollectionNav
+│ │ │ └─┬ Nav
+│ │ │   ├── Dropdown
+│ │ │   ├── DropdownItem
+│ │ │   └── NavItem
+│ │ ├── IconBurger
+│ │ └── IconCross
+│ ├─┬ ErrorMessage
+│ │ ├── Button
+│ │ └── HeroMessage
+│ ├─┬ Main
+│ │ ├── LoadingBar
+│ │ └─┬ NotificationCentre
+│ │   └── Notification
+│ └── Page
+├─┬ HomeView
+│ ├─┬ Header
+│ │ ├─┬ CollectionNav
+│ │ │ └─┬ Nav
+│ │ │   ├── Dropdown
+│ │ │   ├── DropdownItem
+│ │ │   └── NavItem
+│ │ ├── IconBurger
+│ │ └── IconCross
+│ ├── HeroMessage
+│ ├─┬ Main
+│ │ ├── LoadingBar
+│ │ └─┬ NotificationCentre
+│ │   └── Notification
+│ └── Page
+├─┬ PasswordResetView
+│ ├── Banner
+│ ├── Button
+│ ├── Label
+│ └── TextInput
+├─┬ SignInView
+│ ├── Banner
+│ ├── Button
+│ ├── Label
+│ └── TextInput
+├── SignOutView
+├─┬ ProfileEditView
+│ └─┬ ProfileEdit
+│   ├─┬ DocumentEdit
+│   │ ├─┬ ErrorMessage
+│   │ │ ├── Button
+│   │ │ └── HeroMessage
+│   │ └── SubNavItem
+│   ├─┬ DocumentList
+│   │ ├── Button
+│   │ ├─┬ ErrorMessage
+│   │ │ ├── Button
+│   │ │ └── HeroMessage
+│   │ ├── HeroMessage
+│   │ └─┬ SyncTable
+│   │   ├── Table
+│   │   ├─┬ TableHead
+│   │   │ └─┬ TableHeadCell
+│   │   │   └── IconArrow
+│   │   ├─┬ TableHeadCell
+│   │   │ └── IconArrow
+│   │   ├─┬ TableRow
+│   │   │ └── TableRowCell
+│   │   └── TableRowCell
+│   ├─┬ DocumentListToolbar
+│   │ ├── Button
+│   │ ├─┬ ButtonWithPrompt
+│   │ │ ├── Button
+│   │ │ └─┬ Prompt
+│   │ │   └── Button
+│   │ ├── Checkbox
+│   │ ├─┬ Paginator
+│   │ │ └── Button
+│   │ ├── Toolbar
+│   │ └─┬ ToolbarTextInput
+│   │   └── TextInput
+│   ├─┬ Header
+│   │ ├─┬ CollectionNav
+│   │ │ └─┬ Nav
+│   │ │   ├── Dropdown
+│   │ │   ├── DropdownItem
+│   │ │   └── NavItem
+│   │ ├── IconBurger
+│   │ └── IconCross
+│   ├─┬ Main
+│   │ ├── LoadingBar
+│   │ └─┬ NotificationCentre
+│   │   └── Notification
+│   ├── Page
+│   ├─┬ ProfileEditToolbar
+│   │ ├── Button
+│   │ ├─┬ ButtonWithOptions
+│   │ │ ├── Button
+│   │ │ ├── Dropdown
+│   │ │ ├── DropdownItem
+│   │ │ └── IconArrow
+│   │ ├─┬ ButtonWithPrompt
+│   │ │ ├── Button
+│   │ │ └─┬ Prompt
+│   │ │   └── Button
+│   │ ├── DateTime
+│   │ ├─┬ Peer
+│   │ │ └── Button
+│   │ └── Toolbar
+│   ├─┬ ReferencedDocumentHeader
+│   │ └── Button
+│   └── SubNavItem
+└── View
 
 ```

--- a/docs/components/FileUpload.md
+++ b/docs/components/FileUpload.md
@@ -16,6 +16,15 @@ File type acceptance.
 ### `allowDrop`
 
 - type: `bool`
+- default value: `false`
+
+
+### `multiple`
+
+Whether to accept multiple files.
+
+- type: `bool`
+- default value: `false`
 
 
 ### `onChange`

--- a/docs/containers/DocumentList.md
+++ b/docs/containers/DocumentList.md
@@ -71,13 +71,6 @@ The name of a reference field currently being edited.
 - type: `string`
 
 
-### `selectLimit`
-
-The maximum number of documents that can be selected at the same time.
-
-- type: `number`
-
-
 ### `sort`
 
 The name of the field currently being used to sort the documents.

--- a/frontend/actions/documentActions.js
+++ b/frontend/actions/documentActions.js
@@ -151,7 +151,7 @@ export function saveDocument ({
       // null, it's good as it is.
       if (payload[field] && fieldSchema.type === 'Reference') {
         const referencedDocument = payload[field]
-        const referencedDocuments = referencedDocument instanceof Array ?
+        const referencedDocuments = Array.isArray(referencedDocument) ?
             referencedDocument : [referencedDocument]
         const referenceLimit = (
           fieldSchema.settings &&

--- a/frontend/actions/userActions.js
+++ b/frontend/actions/userActions.js
@@ -88,7 +88,7 @@ export function saveUser ({api, collection, user}) {
 
       let validationErrors = getState().document.validationErrors[passwordField] || []
 
-      if (errors instanceof Array) {
+      if (Array.isArray(errors)) {
         errors.forEach(error => {
           if (error.details && error.details.includes('\'WRONG_PASSWORD\'')) {
             validationErrors.push(Constants.ERROR_WRONG_PASSWORD)

--- a/frontend/components/FieldImage/FieldImage.css
+++ b/frontend/components/FieldImage/FieldImage.css
@@ -8,13 +8,19 @@
   padding: 8px 10px;
 }
 
-.preview {
+.thumbnails {
+  margin-right: 20px;
+}
+
+.thumbnail {
+  display: block;
   border-radius: 3px;
-  width: auto;
-  height: auto;
-  max-height: 110px;
-  max-width: 50%;
-  margin-right: 10px;
+  max-width: 250px;
+  width: 100%;
+}
+
+.thumbnail + .thumbnail {
+  margin-top: 5px;
 }
 
 .placeholder {

--- a/frontend/components/FieldImage/FieldImageEdit.jsx
+++ b/frontend/components/FieldImage/FieldImageEdit.jsx
@@ -106,20 +106,25 @@ export default class FieldImageEdit extends Component {
       value
     } = this.props
     const displayName = schema.label || schema._id
-    const src = this.getImageSrc(value)
-    const isReference = schema.type === 'Reference'
     const fieldLocalType = schema.publish && schema.publish.subType ? schema.publish.subType : schema.type
     const href = buildUrl(...onBuildBaseUrl(), 'select', schema._id)
+    const isReference = schema.type === 'Reference'
+    const singleFile = schema.settings && schema.settings.limit === 1
+    const values = value && !(value instanceof Array) ? [value] : value
 
     return (
       <Label label={displayName}>
-        {value &&
+        {values &&
           <div class={styles['value-container']}>
-            <img
-              class={styles.preview}
-              src={src}
-            />
-            
+            <div class={styles.thumbnails}>
+              {values.map(value => (
+                <img
+                  class={styles.thumbnail}
+                  src={this.getImageSrc(value)}
+                />
+              ))}
+            </div>
+
             <Button
               accent="destruct"
               size="small"
@@ -129,7 +134,7 @@ export default class FieldImageEdit extends Component {
           </div>          
         }
 
-        {!value &&
+        {!values &&
           <div>
             <div class={styles.placeholder}>
               <Button
@@ -144,6 +149,7 @@ export default class FieldImageEdit extends Component {
               <FileUpload
                 allowDrop={true}
                 accept={config.accept}
+                multiple={!singleFile}
                 onChange={this.handleFileChange.bind(this)}
               />
             </div>
@@ -174,26 +180,40 @@ export default class FieldImageEdit extends Component {
     }
   }
 
-  handleFileChange(file) {
+  handleFileChange(files) {
     const {
       config,
       onChange,
       schema
     } = this.props
-    const reader = new FileReader()
-    
-    reader.onload = event => {
-      if (typeof onChange === 'function') {
-        onChange.call(this, schema._id, {
+    const singleFile = schema.settings && schema.settings.limit === 1
+
+    let processedFiles = []
+
+    for (let index = 0; index < files.length; index++) {
+      const file = files[index]
+      const reader = new FileReader()
+
+      reader.onload = event => {
+        processedFiles[index] = {
           _file: file,
           _previewData: reader.result,
           contentLength: file.size,
           fileName: file.name,
           mimetype: file.type
-        })
-      }
-    }
+        }
 
-    reader.readAsDataURL(file)
+        if (
+          processedFiles.length === files.length &&
+          typeof onChange === 'function'
+        ) {
+          const finalFiles = singleFile ? processedFiles[0] : processedFiles
+
+          onChange.call(this, schema._id, finalFiles)
+        }
+      }
+
+      reader.readAsDataURL(file)
+    }
   }
 }

--- a/frontend/components/FieldImage/FieldImageEdit.jsx
+++ b/frontend/components/FieldImage/FieldImageEdit.jsx
@@ -110,7 +110,7 @@ export default class FieldImageEdit extends Component {
     const href = buildUrl(...onBuildBaseUrl(), 'select', schema._id)
     const isReference = schema.type === 'Reference'
     const singleFile = schema.settings && schema.settings.limit === 1
-    const values = value && !(value instanceof Array) ? [value] : value
+    const values = (value && !Array.isArray(value)) ? [value] : value
 
     return (
       <Label label={displayName}>

--- a/frontend/components/FieldReference/FieldReferenceEdit.jsx
+++ b/frontend/components/FieldReference/FieldReferenceEdit.jsx
@@ -118,6 +118,7 @@ export default class FieldReferenceEdit extends Component {
     const displayField = value &&
       Object.keys(filterHiddenFields(referencedCollection.fields, 'list'))[0]
     const href = buildUrl(...onBuildBaseUrl(), 'select', schema._id)
+    const values = value && !(value instanceof Array) ? [value] : value
 
     return (
       <Label
@@ -126,7 +127,11 @@ export default class FieldReferenceEdit extends Component {
         {value
           ? (
             <div class={styles['value-container']}>
-              <p class={styles.value}>{displayField && value[displayField]}</p>
+              <div>
+                {values.map(value => (
+                  <p class={styles.value}>{displayField && value[displayField]}</p>
+                ))}
+              </div>
 
               <Button
                 accent="destruct"

--- a/frontend/components/FieldString/FieldStringEdit.jsx
+++ b/frontend/components/FieldString/FieldStringEdit.jsx
@@ -290,7 +290,7 @@ export default class FieldStringEdit extends Component {
     let hasValidationErrors = false
 
     // Are we dealing with multiple values?
-    if (value instanceof Array) {
+    if (Array.isArray(value)) {
       // If the field is required and we don't have any values selected,
       // there's a validation error.
       hasValidationErrors = schema.required && (value.length === 0)

--- a/frontend/components/FieldString/FieldStringList.jsx
+++ b/frontend/components/FieldString/FieldStringList.jsx
@@ -31,7 +31,7 @@ export default class FieldStringList extends Component {
     if (!value) return null
 
     // If the value is an array, we render each option individually.
-    if (value instanceof Array) {
+    if (Array.isArray(value)) {
       return this.renderOptions(value, schema)
     }
 

--- a/frontend/components/FileUpload/FileUpload.jsx
+++ b/frontend/components/FileUpload/FileUpload.jsx
@@ -12,15 +12,20 @@ import Button from 'components/Button/Button'
 export default class FileUpload extends Component {
 
   static propTypes = {
+    /**
+     * File type acceptance.
+     */
+    accept: proptypes.string,
+
     /*
      * Allow drag and drop upload.
      */
     allowDrop: proptypes.bool,
 
     /**
-     * File type acceptance.
+     * Whether to accept multiple files.
      */
-    accept: proptypes.string,
+    multiple: proptypes.bool,
 
     /**
      * Callback to be executed when there is a change in the value of the field.
@@ -28,8 +33,14 @@ export default class FileUpload extends Component {
     onChange: proptypes.func
   }
 
-  constructor (props) {
+  static defaultProps = {
+    allowDrop: false,
+    multiple: false
+  }
+
+  constructor(props) {
     super(props)
+
     this.state.dragOver = false
   }
 
@@ -38,7 +49,11 @@ export default class FileUpload extends Component {
   }
 
   render() {
-    const {allowDrop, accept} = this.props
+    const {
+      accept,
+      allowDrop,
+      multiple
+    } = this.props
     const {dragOver} = this.state
 
     const dropStyles = new Style(styles, 'container')
@@ -65,6 +80,7 @@ export default class FileUpload extends Component {
           accept={accept}
           class={styles['file-input']}
           id={this.fileInputId}
+          multiple={multiple}
           type="file"
           onChange={this.handleFileSelect.bind(this)}
         />
@@ -81,7 +97,7 @@ export default class FileUpload extends Component {
   handleFileSelect(event) {
     const {onChange} = this.props
 
-    onChange(event.target.files[0])
+    onChange(event.target.files)
 
     event.preventDefault()
   }
@@ -90,7 +106,8 @@ export default class FileUpload extends Component {
     const {onChange} = this.props
 
     this.setState({dragOver: false})
-    onChange(event.dataTransfer.files[0])
+
+    onChange(event.dataTransfer.files)
     event.preventDefault()
   }
 

--- a/frontend/containers/DocumentList/DocumentList.jsx
+++ b/frontend/containers/DocumentList/DocumentList.jsx
@@ -74,11 +74,6 @@ class DocumentList extends Component {
     referencedField: proptypes.string,
 
     /**
-     * The maximum number of documents that can be selected at the same time.
-     */
-    selectLimit: proptypes.number,
-
-    /**
      * The name of the field currently being used to sort the documents.
      */
     sort: proptypes.string,
@@ -338,12 +333,13 @@ class DocumentList extends Component {
       referencedField,
       onPageTitle,
       order,
-      selectLimit,
       sort,
       state
     } = this.props
     const documents = state.documents.list.results
     const selectedRows = this.getSelectedRows()
+
+    let selectLimit = Infinity
 
     // If we're on a reference field select view, we'll see if there's a field
     // component for the referenced field type that exports a `referenceSelect`
@@ -358,6 +354,14 @@ class DocumentList extends Component {
       const fieldType = (fieldSchema.publish && fieldSchema.publish.subType) || fieldSchema.type
       const fieldComponentName = `Field${fieldType}`
       const FieldComponentReferenceSelect = fieldComponents[fieldComponentName].referenceSelect
+
+      if (
+        fieldSchema.settings &&
+        fieldSchema.settings.limit &&
+        fieldSchema.settings.limit > 0
+      ) {
+        selectLimit = fieldSchema.settings.limit
+      }
 
       if (FieldComponentReferenceSelect) {
         return (
@@ -417,9 +421,11 @@ class DocumentList extends Component {
   }
 
   renderField(fieldName, schema, value) {
-    const fieldType = schema.publish && schema.publish.subType ? schema.publish.subType : schema.type
+    const fieldType = schema.publish && schema.publish.subType ?
+      schema.publish.subType : schema.type
     const fieldComponentName = `Field${fieldType}`
-    const FieldComponentList = fieldComponents[fieldComponentName] && fieldComponents[fieldComponentName].list
+    const FieldComponentList = fieldComponents[fieldComponentName] &&
+      fieldComponents[fieldComponentName].list
 
     if (FieldComponentList) {
       return (

--- a/frontend/containers/DocumentList/DocumentList.jsx
+++ b/frontend/containers/DocumentList/DocumentList.jsx
@@ -421,7 +421,7 @@ class DocumentList extends Component {
   }
 
   renderField(fieldName, schema, value) {
-    const fieldType = schema.publish && schema.publish.subType ?
+    const fieldType = (schema.publish && schema.publish.subType) ?
       schema.publish.subType : schema.type
     const fieldComponentName = `Field${fieldType}`
     const FieldComponentList = fieldComponents[fieldComponentName] &&

--- a/frontend/containers/DocumentListToolbar/DocumentListToolbar.jsx
+++ b/frontend/containers/DocumentListToolbar/DocumentListToolbar.jsx
@@ -176,6 +176,8 @@ class DocumentListToolbar extends Component {
   renderReferencedDocumentActions() {
     const {state} = this.props
     const selectedDocuments = state.documents.selected
+    const ctaText = selectedDocuments.length > 1 ?
+      'Add selected documents' : 'Add selected document'
 
     return (
       <div class={styles.actions}>
@@ -183,7 +185,7 @@ class DocumentListToolbar extends Component {
           accent="save"
           disabled={!selectedDocuments.length}
           onClick={this.handleReferencedDocumentSelect.bind(this)}
-        >Add selected document</Button>
+        >{ctaText}</Button>
       </div>
     )
   }
@@ -264,13 +266,14 @@ class DocumentListToolbar extends Component {
 
     // We might want to change this when we allow a field to reference multiple
     // documents. For now, we just get the first selected document.
-    const selectedDocumentId = state.documents.selected[0]
-    const selectedDocument = documentsList.find(document => {
-      return document._id === selectedDocumentId
-    })
+    const selectedDocuments = state.documents.selected.map(documentId => {
+      return documentsList.find(document => {
+        return document._id === documentId
+      })
+    }).filter(Boolean)
 
     actions.updateLocalDocument({
-      [referencedField]: selectedDocument
+      [referencedField]: selectedDocuments
     }, {
       collection,
       group

--- a/frontend/views/DocumentListView/DocumentListView.jsx
+++ b/frontend/views/DocumentListView/DocumentListView.jsx
@@ -72,7 +72,6 @@ export default class DocumentListView extends Component {
               page={page}
               parentDocumentId={documentId}
               referencedField={referencedField}
-              selectLimit={referencedField ? 1 : undefined}
               sort={sort}
             />
           </div>        


### PR DESCRIPTION
This PR implements #214, adding support for reference fields with multiple documents, based on the `settings.limit` property.

This is for non-media reference fields only — do we want to do the same for media fields, @mingard?