### PR TITLE
feat: make sessions global

### DIFF
--- a/app/lib/controllers/api-bridge.js
+++ b/app/lib/controllers/api-bridge.js
@@ -38,10 +38,10 @@ APIBridgeController.prototype.post = function (req, res, next) {
 
   res.header('Content-Type', 'application/json')
 
+  // Block any API requests if there's no session
   if (!req.isAuthenticated()) {
-    // Currently always returning false. Needs review
-    // res.write(JSON.stringify({err: 'AUTH_FAILED'}))
-    // res.end()
+    res.write(JSON.stringify({err: 'AUTH_FAILED'}))
+    res.end()
   }
 
   try {

--- a/app/lib/controllers/session.js
+++ b/app/lib/controllers/session.js
@@ -24,7 +24,15 @@ Session.prototype.authorise = function (email, password, next) {
     .whereFieldIsEqualTo('password', password)
     .find({extractResults: true}).then(user => {
       if (user.length > 0) {
-        return next(null, user[0])
+        // Return only required fields
+        const authUser = {
+          first_name: user[0].first_name,
+          last_name: user[0].last_name,
+          email: user[0].email,
+          _id: user[0]._id,
+          handle: user[0].handle
+        }
+        return next(null, authUser)
       } else {
         return next(null)
       }

--- a/app/lib/router/index.js
+++ b/app/lib/router/index.js
@@ -55,11 +55,11 @@ Router.prototype.setPassportStrategies = function () {
   // Passport Local stategy selected
   passport.use(new LocalStrategy(sessionController.authorise))
 
-  passport.serializeUser((user, done) => 
+  passport.serializeUser((user, done) =>
     done(!user ? {err: 'User not found'} : null, user || null)
   )
 
-  passport.deserializeUser((user, done) => 
+  passport.deserializeUser((user, done) =>
     done(!user ? {err: 'User not found'} : null, user || null)
   )
 }

--- a/app/lib/router/index.js
+++ b/app/lib/router/index.js
@@ -1,9 +1,15 @@
 'use strict'
 
+const cookieParser = require('restify-cookies')
+const session = require('cookie-session')
+const flash = require('connect-flash')
+const fs = require('fs')
+const path = require('path')
+const passport = require('passport-restify')
+const LocalStrategy = require('passport-local')
 const restify = require('restify')
 const serveStatic = require('serve-static-restify')
-const path = require('path')
-const fs = require('fs')
+const SessionController = require(`${paths.lib.controllers}/session`)
 
 /**
  * @constructor
@@ -23,6 +29,7 @@ Router.prototype.addRoutes = function (app) {
 
   this.pre()
   this.use()
+  this.setPassportStrategies()
   this.setHeaders() // Only run when no redirects
   this.getRoutes()
   this.componentRoutes(path.resolve(`${paths.frontend.components}`), /Routes$/g)
@@ -36,6 +43,25 @@ Router.prototype.getRoutes = function () {
 
     controller(this.app)
   })
+}
+
+/**
+ * Set Passport Strategies
+ * Add local sessionController strategies to passport.
+ */
+Router.prototype.setPassportStrategies = function () {
+  const sessionController = new SessionController()
+
+  // Passport Local stategy selected
+  passport.use(new LocalStrategy(sessionController.authorise))
+
+  passport.serializeUser((user, done) => 
+    done(!user ? {err: 'User not found'} : null, user || null)
+  )
+
+  passport.deserializeUser((user, done) => 
+    done(!user ? {err: 'User not found'} : null, user || null)
+  )
 }
 
 /**
@@ -96,6 +122,18 @@ Router.prototype.use = function () {
     .use(restify.requestLogger())
     .use(restify.queryParser())
     .use(restify.bodyParser({mapParams: true})) // Changing to false throws issues with auth. Needs addressing
+    .use(cookieParser.parse)
+    // Add session.
+    .use(session({
+      key: 'dadi-publish',
+      secret: 'keyboard cat',
+      saveUninitialized: true,
+      resave: true
+    }))
+    // Initialise passport session.
+    .use(passport.initialize())
+    .use(passport.session())
+    .use(flash())
 }
 
 /**

--- a/app/lib/router/routes/api-bridge.js
+++ b/app/lib/router/routes/api-bridge.js
@@ -5,6 +5,7 @@ const APIBridgeController = require(`${paths.lib.controllers}/api-bridge`)
 
 module.exports = function (app) {
   const controller = new APIBridgeController()
+  
   app.use(restify.throttle({
     burst: 100,
     rate: 50,

--- a/app/lib/router/routes/api-bridge.js
+++ b/app/lib/router/routes/api-bridge.js
@@ -5,7 +5,7 @@ const APIBridgeController = require(`${paths.lib.controllers}/api-bridge`)
 
 module.exports = function (app) {
   const controller = new APIBridgeController()
-  
+
   app.use(restify.throttle({
     burst: 100,
     rate: 50,

--- a/app/lib/router/routes/session.js
+++ b/app/lib/router/routes/session.js
@@ -1,44 +1,11 @@
 'use strict'
 
-const cookieParser = require('restify-cookies')
-const session = require('cookie-session')
-const flash = require('connect-flash')
 const passport = require('passport-restify')
-const LocalStrategy = require('passport-local')
 
 const SessionController = require(`${paths.lib.controllers}/session`)
 
 module.exports = function (app) {
-  let sessionController = new SessionController()
-
-  // Add session rules
-  app.use(cookieParser.parse)
-  app.use(session({
-    key: 'dadi-publish',
-    secret: 'keyboard cat',
-    saveUninitialized: true,
-    resave: true
-  }))
-  // Initialise passport session
-  app.use(passport.initialize())
-  app.use(passport.session())
-  app.use(flash())
-
-  // Passport Local stategy selected
-  passport.use(new LocalStrategy(sessionController.authorise))
-
-  passport.serializeUser((user, done) => {
-    if (!user) return done({err: 'User not found'}, null)
-
-    return done(null, user)
-  })
-
-  passport.deserializeUser((user, done) => {
-    if (!user) return done({err: 'No session'}, null)
-
-    return done(null, user)
-  })
-
+  const sessionController = new SessionController()
   // Reset token request endpoint.
   app.post({
     name: 'session-password-reset',
@@ -56,9 +23,7 @@ module.exports = function (app) {
     path: '/session'
   }, sessionController.get)
 
-  app.post('/session', (req, res, next) => {
-    return sessionController.post(req, res, next, passport)
-  })
+  app.post('/session', (req, res, next) => sessionController.post(req, res, next, passport))
 
   app.put('/session', sessionController.put)
 

--- a/app/lib/router/routes/session.js
+++ b/app/lib/router/routes/session.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const passport = require('passport-restify')
-
 const SessionController = require(`${paths.lib.controllers}/session`)
 
 module.exports = function (app) {

--- a/frontend/actions/userActions.js
+++ b/frontend/actions/userActions.js
@@ -88,16 +88,12 @@ function runSessionQuery ({
     request.body = JSON.stringify(payload)
   }
 
-  return fetch(path, request).then(response => {
-    return response.json()
-      .then(parsedResponse => {
-        if (response.status === 200) {
-          return parsedResponse
-        }
-
-        return Promise.reject(parsedResponse)
-      })
-  })
+  return fetch(path, request).then(response =>
+    response.json()
+      .then(parsedResponse => 
+        response.status === 200 ? parsedResponse : Promise.reject(parsedResponse)
+      )
+  )
 }
 
 /**

--- a/frontend/actions/userActions.js
+++ b/frontend/actions/userActions.js
@@ -90,7 +90,7 @@ function runSessionQuery ({
 
   return fetch(path, request).then(response =>
     response.json()
-      .then(parsedResponse => 
+      .then(parsedResponse =>
         response.status === 200 ? parsedResponse : Promise.reject(parsedResponse)
       )
   )

--- a/frontend/containers/App/App.jsx
+++ b/frontend/containers/App/App.jsx
@@ -85,7 +85,9 @@ class App extends Component {
     if (this.socket.getRoom() !== room) {
       this.socket.setRoom(room)
     }
-    // TO-TO Handle leaving a room when the component changes.
+    if (previousState.user.remote !== this.socket.getUser()) {
+      this.socket.setUser(previousState.user.remote)
+    }
   }
 
   render() {


### PR DESCRIPTION
This PR addresses an issue where the passport authentication was not globally accessible and thus could not be used to block API requests for an unauthenticated user.