### PR TITLE
Use correct redirect link when selecting referenced documents

### DIFF
--- a/frontend/views/DocumentListView/DocumentListView.jsx
+++ b/frontend/views/DocumentListView/DocumentListView.jsx
@@ -109,8 +109,12 @@ export default class DocumentListView extends Component {
       referencedField
     } = this.props
 
-    if (documentId && referencedField) {
-      return [group, collection, 'document', 'edit', documentId, data.section]
+    if (referencedField) {
+      if (documentId) {
+        return [group, collection, 'document', 'edit', documentId, data.section]
+      }
+
+      return [group, collection, 'document', 'new', data.section]
     }
 
     return [group, collection, 'documents']


### PR DESCRIPTION
This fixes an issue where selecting a reference document when creating a new document redirects to the wrong URL.