### PR TITLE
Fix issue with "Save as new" action

### DIFF
--- a/docs/component-architecture.md
+++ b/docs/component-architecture.md
@@ -19,7 +19,6 @@ App
 │ │ │ └── HeroMessage
 │ │ └── SubNavItem
 │ ├─┬ DocumentEditToolbar
-│ │ ├── Button
 │ │ ├─┬ ButtonWithOptions
 │ │ │ ├── Button
 │ │ │ ├── Dropdown
@@ -53,7 +52,6 @@ App
 │ │ │ └── HeroMessage
 │ │ └── SubNavItem
 │ ├─┬ DocumentEditToolbar
-│ │ ├── Button
 │ │ ├─┬ ButtonWithOptions
 │ │ │ ├── Button
 │ │ │ ├── Dropdown
@@ -101,7 +99,6 @@ App
 │ │ ├── Button
 │ │ ├─┬ DocumentFilters
 │ │ │ ├─┬ DocumentFilter
-│ │ │ │ ├── TextInput
 │ │ │ │ └── Button
 │ │ │ └── Button
 │ │ └─┬ ListController
@@ -172,10 +169,24 @@ App
 │ ├── Label
 │ └── TextInput
 ├─┬ SignInView
-│ ├── Banner
-│ ├── Button
-│ ├── Label
-│ └── TextInput
+│ ├─┬ SignIn
+│ │ ├── Banner
+│ │ ├── Button
+│ │ ├── Label
+│ │ └── TextInput
+│ ├─┬ Header
+│ │ ├─┬ CollectionNav
+│ │ │ └─┬ Nav
+│ │ │   ├── Dropdown
+│ │ │   ├── DropdownItem
+│ │ │   └── NavItem
+│ │ ├── IconBurger
+│ │ └── IconCross
+│ ├─┬ Main
+│ │ ├── LoadingBar
+│ │ └─┬ NotificationCentre
+│ │   └── Notification
+│ └── Page
 ├── SignOutView
 ├─┬ ProfileEditView
 │ └─┬ ProfileEdit

--- a/docs/components/DocumentFilter.md
+++ b/docs/components/DocumentFilter.md
@@ -6,6 +6,13 @@ A document filter.
 Props
 -----
 
+### `config`
+
+App config.
+
+- type: `object`
+
+
 ### `field`
 
 The slug of the field being filtered.
@@ -17,6 +24,13 @@ The slug of the field being filtered.
 
 An object containing the fields available for the given collection.
 Keys represent field slugs and values hold the field schema.
+
+- type: `object`
+
+
+### `filters`
+
+An object containing the current applied filters.
 
 - type: `object`
 

--- a/docs/components/DocumentFilters.md
+++ b/docs/components/DocumentFilters.md
@@ -13,6 +13,13 @@ The schema of the collection being filtered.
 - type: `object`
 
 
+### `config`
+
+App config.
+
+- type: `object`
+
+
 ### `filter`
 
 The JSON-stringified object of filters currently applied.

--- a/docs/components/FieldBooleanFilter.md
+++ b/docs/components/FieldBooleanFilter.md
@@ -1,0 +1,42 @@
+`FieldBooleanFilter`
+====================
+
+Component for rendering API fields of type Boolean in a filter.
+
+Props
+-----
+
+### `analyserStyles`
+
+Classes for the analyser selection.
+
+- type: `string`
+
+
+### `containerStyles`
+
+Classes for the container.
+
+- type: `string`
+
+
+### `index`
+
+Filter array position.
+
+- type: `number`
+
+
+### `onUpdate`
+
+Input update callback.
+
+- type: `func`
+
+
+### `value`
+
+Field value.
+
+- type: `string`
+

--- a/docs/components/FieldDateTimeFilter.md
+++ b/docs/components/FieldDateTimeFilter.md
@@ -1,0 +1,63 @@
+`FieldDateTimeFilter`
+=====================
+
+Component for rendering API fields of type DateTime in a filter.
+
+Props
+-----
+
+### `analyserStyles`
+
+Classes for the analyser selection.
+
+- type: `string`
+
+
+### `config`
+
+App config.
+
+- type: `object`
+
+
+### `containerStyles`
+
+Classes for the container.
+
+- type: `string`
+
+
+### `index`
+
+Filter array position.
+
+- type: `number`
+
+
+### `onUpdate`
+
+Input update callback.
+
+- type: `func`
+
+
+### `type`
+
+Field type.
+
+- type: `string`
+
+
+### `value`
+
+Field value.
+
+- type: `string`
+
+
+### `valueStyles`
+
+Classes for the value input.
+
+- type: `string`
+

--- a/docs/components/FieldNumberFilter.md
+++ b/docs/components/FieldNumberFilter.md
@@ -1,0 +1,56 @@
+`FieldNumberFilter`
+===================
+
+Component for rendering API fields of type Number in a filter.
+
+Props
+-----
+
+### `analyserStyles`
+
+Classes for the analyser selection.
+
+- type: `string`
+
+
+### `containerStyles`
+
+Classes for the container.
+
+- type: `string`
+
+
+### `index`
+
+Filter array position.
+
+- type: `number`
+
+
+### `onUpdate`
+
+Input update callback.
+
+- type: `func`
+
+
+### `type`
+
+Field type.
+
+- type: `string`
+
+
+### `value`
+
+Field value.
+
+- type: `string`
+
+
+### `valueStyles`
+
+Classes for the value input.
+
+- type: `string`
+

--- a/docs/components/FieldStringFilter.md
+++ b/docs/components/FieldStringFilter.md
@@ -1,0 +1,56 @@
+`FieldStringFilter`
+===================
+
+Component for rendering API fields of type String in a filter.
+
+Props
+-----
+
+### `analyserStyles`
+
+Classes for the analyser selection.
+
+- type: `string`
+
+
+### `containerStyles`
+
+Classes for the container.
+
+- type: `string`
+
+
+### `index`
+
+Filter array position.
+
+- type: `number`
+
+
+### `onUpdate`
+
+Input update callback.
+
+- type: `func`
+
+
+### `type`
+
+Field type.
+
+- type: `string`
+
+
+### `value`
+
+Field value.
+
+- type: `string`
+
+
+### `valueStyles`
+
+Classes for the value input.
+
+- type: `string`
+

--- a/docs/components/TextInput.md
+++ b/docs/components/TextInput.md
@@ -97,6 +97,13 @@ Type/function of the input field.
 - default value: `'text'`
 
 
+### `validation`
+
+Callback to be executed onChange to validate field value.
+
+- type: `func`
+
+
 ### `value`
 
 Current value of the input field.

--- a/docs/containers/DocumentEditToolbar.md
+++ b/docs/containers/DocumentEditToolbar.md
@@ -6,18 +6,18 @@ A toolbar used in a document edit view.
 Props
 -----
 
+### `actions`
+
+The global actions object.
+
+- type: `object`
+
+
 ### `collection`
 
 The name of the collection currently being listed.
 
 - type: `string`
-
-
-### `dispatch`
-
-The global actions dispatcher.
-
-- type: `func`
 
 
 ### `documentId`

--- a/docs/containers/SignIn.md
+++ b/docs/containers/SignIn.md
@@ -1,0 +1,21 @@
+`SignIn`
+========
+
+
+
+Props
+-----
+
+### `setPagetTitle`
+
+The method used to update the current page title.
+
+- type: `func`
+
+
+### `token`
+
+Sign in token.
+
+- type: `string`
+

--- a/frontend/containers/DocumentEditToolbar/DocumentEditToolbar.jsx
+++ b/frontend/containers/DocumentEditToolbar/DocumentEditToolbar.jsx
@@ -24,26 +24,20 @@ import DateTime from 'components/DateTime/DateTime'
 import Peer from 'components/Peer/Peer'
 import Toolbar from 'components/Toolbar/Toolbar'
 
-const actions = {
-  ...appActions,
-  ...documentActions,
-  ...documentsActions
-}
-
 /**
  * A toolbar used in a document edit view.
  */
 class DocumentEditToolbar extends Component {
   static propTypes = {
     /**
+     * The global actions object.
+     */
+    actions: proptypes.object,
+
+    /**
      * The name of the collection currently being listed.
      */
     collection: proptypes.string,
-
-    /**
-     * The global actions dispatcher.
-     */
-    dispatch: proptypes.func,
 
     /**
      * The ID of the document being edited.
@@ -84,7 +78,7 @@ class DocumentEditToolbar extends Component {
 
   componentDidUpdate(prevProps, prevState) {
     const {
-      dispatch,
+      actions,
       collection,
       group,
       state
@@ -113,9 +107,9 @@ class DocumentEditToolbar extends Component {
       // Redirect to document list view
       route(buildUrl(group, collection, 'documents'))
 
-      dispatch(actions.setNotification({
+      actions.setNotification({
         message: 'The documents have been deleted'
-      }))
+      })
     }
   }
 
@@ -209,8 +203,8 @@ class DocumentEditToolbar extends Component {
 
   handleDelete() {
     const {
+      actions,
       collection,
-      dispatch,
       group,
       referencedField,
       state
@@ -233,13 +227,13 @@ class DocumentEditToolbar extends Component {
     }
 
     if (document._id) {
-      dispatch(actions.deleteDocuments(query))
+      actions.deleteDocuments(query)
     }
   }
 
   handleSave(saveMode) {
     const {
-      dispatch,
+      actions,
       collection,
       group,
       section,
@@ -254,9 +248,9 @@ class DocumentEditToolbar extends Component {
           callback: documentId => {
             route(buildUrl(group, collection, 'document', 'edit', documentId, section))
 
-            dispatch(actions.setNotification({
+            actions.setNotification({
               message:`The document has been ${newDocument ? 'created' : 'updated'}`
-            }))
+            })
           }
         }
 
@@ -268,14 +262,11 @@ class DocumentEditToolbar extends Component {
           callback: documentId => {
             route(buildUrl(group, collection, 'document', 'new'))
 
-            dispatch(
-              batchActions(
-                actions.setNotification({
-                  message: `The document has been ${newDocument ? 'created' : 'updated'}`
-                }),
-                actions.clearRemoteDocument()
-              )
-            )          
+            actions.setNotification({
+              message: `The document has been ${newDocument ? 'created' : 'updated'}`
+            })
+
+            actions.clearRemoteDocument()
           }
         }
 
@@ -287,9 +278,9 @@ class DocumentEditToolbar extends Component {
           callback: documentId => {
             route(buildUrl(group, collection, 'documents'))
 
-            dispatch(actions.setNotification({
+            actions.setNotification({
               message: `The document has been ${newDocument ? 'created' : 'updated'}`
-            }))  
+            })
           }
         }
 
@@ -301,9 +292,9 @@ class DocumentEditToolbar extends Component {
           callback: documentId => {
             route(buildUrl(group, collection, 'document', 'edit', documentId, section))
 
-            dispatch(actions.setNotification({
+            actions.setNotification({
               message: `The document has been created`
-            }))  
+            })
           },
           createNew: true
         }
@@ -311,13 +302,13 @@ class DocumentEditToolbar extends Component {
         break
     }    
 
-    dispatch(actions.registerSaveAttempt())
+    actions.registerSaveAttempt()
   }
 
   saveDocument() {
     const {
+      actions,
       collection,
-      dispatch,
       documentId,
       group,
       referencedField,
@@ -350,14 +341,14 @@ class DocumentEditToolbar extends Component {
       document = Object.assign({}, state.document.remote, state.document.local)
     }
 
-    dispatch(actions.saveDocument({
+    actions.saveDocument({
       api: currentApi,
       collection: currentCollection,
       document,
       documentId: creatingNew ? null : documentId,
       group,
       urlCollection: collection
-    }))
+    })
   }
 }
 
@@ -366,5 +357,10 @@ export default connectHelper(
     api: state.api,
     app: state.app,
     document: state.document
-  })
+  }),
+  dispatch => bindActionCreators({
+    ...appActions,
+    ...documentActions,
+    ...documentsActions
+  }, dispatch)
 )(DocumentEditToolbar)


### PR DESCRIPTION
This PR fixes #229. `batchActions()` doesn't seem to work well with asynchronous actions (to be further investigated), so for now I've made it so we're firing two separate actions. As a consequence, I've also reverted this file to bounded action creators.