### PR TITLE
Add fadeAfterSeconds setting to NotificationCentre

### DIFF
--- a/frontend/components/Notification/Notification.css
+++ b/frontend/components/Notification/Notification.css
@@ -22,6 +22,7 @@
   padding: 10px 50px;
   border-bottom-left-radius: 3px;
   border-bottom-right-radius: 3px;
+  transition: all 0.2s ease-out;
 }
 
 .notification-visible {
@@ -32,6 +33,10 @@
 .notification-system {
   background-color: var(--theme-colour-system, #ffbf0d);
   color: var(--theme-colour-primary, #000000);
+}
+
+.notification-system.notification-faded {
+  background-color: #b3870b;
 }
 
 .option {

--- a/frontend/components/Notification/Notification.jsx
+++ b/frontend/components/Notification/Notification.jsx
@@ -64,6 +64,7 @@ export default class Notification extends Component {
   render() {
     const {
       accent,
+      faded,
       message,
       onHover,
       onOptionClick,
@@ -74,6 +75,7 @@ export default class Notification extends Component {
       .addIf('container-visible', visible)
     const notificationStyle = new Style(styles, 'notification')
       .add(`notification-${accent}`)
+      .addIf('notification-faded', faded)
 
     return (
       <div class={containerStyle.getClasses()}>

--- a/frontend/containers/DocumentEdit/DocumentEdit.jsx
+++ b/frontend/containers/DocumentEdit/DocumentEdit.jsx
@@ -161,8 +161,9 @@ class DocumentEdit extends Component {
     // Are there unsaved changes?
     if (!previousDocument.local && document.local && document.loadedFromLocalStorage) {
       const notification = {
+        dismissAfterSeconds: false,
+        fadeAfterSeconds: 5,
         message: 'You have unsaved changes',
-        dismissAfterSeconds: false, // Persist
         options: {
           'Discard them?': actions.discardUnsavedChanges.bind(this, {
             collection,

--- a/frontend/containers/NotificationCentre/NotificationCentre.jsx
+++ b/frontend/containers/NotificationCentre/NotificationCentre.jsx
@@ -27,8 +27,10 @@ class NotificationCentre extends Component {
     super(props)
 
     this.enqueuedNotification = null
-    this.state.visible = false
     this.timeout = null
+
+    this.state.faded = false
+    this.state.visible = false
   }
 
   componentWillReceiveProps(nextProps) {
@@ -46,6 +48,10 @@ class NotificationCentre extends Component {
   shouldComponentUpdate(nextProps, nextState) {
     const notification = this.props.state.app.notification
     const nextNotification = nextProps.state.app.notification
+
+    if (this.state.faded !== nextState.faded) {
+      return true
+    }
 
     if (this.state.visible !== nextState.visible) {
       return true
@@ -92,22 +98,22 @@ class NotificationCentre extends Component {
 
   render() {
     const {state} = this.props
-    const {visible} = this.state
+    const {
+      faded,
+      visible
+    } = this.state
     const notification = this.enqueuedNotification || state.app.notification
 
     if (!notification) return null
 
     const {
-      dismissAfterRouteChange,
-      dismissAfterSeconds,
       message,
-      options,
-      timestamp,
-      type
+      options
     } = notification
 
     return (
       <Notification
+        faded={faded}
         message={message}
         onHover={this.handleOnHover.bind(this)}
         onOptionClick={this.handleOptionClick.bind(this)}
@@ -120,7 +126,8 @@ class NotificationCentre extends Component {
   start() {
     const notification = this.props.state.app.notification
     const {
-      dismissAfterSeconds
+      dismissAfterSeconds,
+      fadeAfterSeconds,
     } = notification
 
     clearTimeout(this.timeout)
@@ -129,8 +136,13 @@ class NotificationCentre extends Component {
       setTimeout(this.dismiss.bind(this), dismissAfterSeconds * 1000)
     }
 
+    if (fadeAfterSeconds) {
+      setTimeout(this.fade.bind(this), fadeAfterSeconds * 1000)
+    }
+
     setTimeout(() => {
       this.setState({
+        faded: false,
         visible: true
       })
     }, 10)
@@ -140,7 +152,14 @@ class NotificationCentre extends Component {
     clearTimeout(this.timeout)
 
     this.setState({
+      faded: false,
       visible: false
+    })
+  }
+
+  fade() {
+    this.setState({
+      faded: true
     })
   }
 


### PR DESCRIPTION
This PR adds a `fadeAfterSeconds` setting to `NotificationCentre`, allowing notifications to enter a less prominent state after a period of time. This state can be styled with the class `notification-faded`.

Closes #225.