### PR TITLE
Add mock for request-promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,8 @@
       "^lib/(.*)": "<rootDir>/frontend/lib/$1",
       "\\.css$": "identity-obj-proxy",
       "^react$": "preact-compat",
-      "^react-dom$": "preact-compat"
+      "^react-dom$": "preact-compat",
+      "request-promise": "<rootDir>/test/mocks/request-promise"
     },
     "moduleFileExtensions": [
       "js",

--- a/test/mocks/request-promise.js
+++ b/test/mocks/request-promise.js
@@ -1,0 +1,5 @@
+// We can add a mocked implementation here if we need this module for
+// any of the tests.
+module.exports = () => {
+  return {}
+}

--- a/test/unit/lib/controllers/session.test.js
+++ b/test/unit/lib/controllers/session.test.js
@@ -1,15 +1,15 @@
 const globals = require(`${__dirname}/../../../../app/globals`) // Always required
-// const Session = require(`${__dirname}/../../../../app/lib/controllers/session`).Session
+const Session = require(`${__dirname}/../../../../app/lib/controllers/session`).Session
 
-// let session
+let session
 
 beforeEach(() => {
-  // session = new Session()
+  session = new Session()
 })
 
 describe('Session', () => {
   it('should export function', () => {
-    // expect(session).toBeInstanceOf(Object)
+    expect(session).toBeInstanceOf(Object)
   })
 })
 


### PR DESCRIPTION
`request-promise` fails when another module tries to expose a `Request` prototype, which I'm assuming Jest does. To get around that, I've added a mock for that module — we don't want the test suite to be doing actual HTTP requests, so I'm sure the mocked module will be useful for other tests.

This closes #253.