### PR TITLE
Change textarea to use value prop

### DIFF
--- a/frontend/components/TextInput/TextInput.jsx
+++ b/frontend/components/TextInput/TextInput.jsx
@@ -135,9 +135,7 @@ export default class TextInput extends Component {
           readonly={readonly}
           required={required}
           rows={10}
-        >
-          {value}
-        </textarea>
+          value={value}/>
       )
     }
 


### PR DESCRIPTION
This PR makes `TextInput` pass the value to textarea nodes using the correct `value` prop, so that the DOM is in sync with the VDOM.

Closes #287.