### PR TITLE
fix: remove duplication that throws error

### DIFF
--- a/frontend/containers/DocumentEditToolbar/DocumentEditToolbar.jsx
+++ b/frontend/containers/DocumentEditToolbar/DocumentEditToolbar.jsx
@@ -120,9 +120,6 @@ class DocumentEditToolbar extends Component {
     } = this.props
     const document = state.document.remote
     const hasConnectionIssues = state.app.networkStatus !== Constants.NETWORK_OK
-      && Object.keys(document.validationErrors)
-        .filter(field => document.validationErrors[field])
-        .length
     const isSaving = state.document.remoteStatus === Constants.STATUS_SAVING
     const validationErrors = state.document.validationErrors
     const hasValidationErrors = validationErrors && Object.keys(validationErrors)

--- a/frontend/containers/ProfileEditToolbar/ProfileEditToolbar.jsx
+++ b/frontend/containers/ProfileEditToolbar/ProfileEditToolbar.jsx
@@ -113,10 +113,6 @@ class ProfileEditToolbar extends Component {
       state
     } = this.props
     const document = state.document.remote
-    const hasConnectionIssues = state.app.networkStatus !== Constants.NETWORK_OK
-      && Object.keys(document.validationErrors)
-        .filter(field => document.validationErrors[field])
-        .length
     const validationErrors = state.document.validationErrors
     const hasValidationErrors = validationErrors && Object.keys(validationErrors)
       .filter(field => validationErrors[field])


### PR DESCRIPTION
The const `hasConnectionIssues` contained a duplication of the logic that sets const `hasValidationErrors`:

```js
const hasConnectionIssues = state.app.networkStatus !== Constants.NETWORK_OK
  && Object.keys(document.validationErrors)
  .filter(field => document.validationErrors[field])
  .length

const hasValidationErrors = validationErrors && Object.keys(validationErrors)
  .filter(field => validationErrors[field])
  .length
```

An error was being thrown because `hasConnectionIssues` did not contain a check for `validationErrors` before attempting to iterate it's keys which alerted me to the fact it did not need to contain the extra logic. `hasCollectionIssues` should only reflect whether the client is connected and not whether `validationErrors` exist.

