### PR TITLE
fix: unload document on exit

### DIFF
--- a/app/lib/models/collection.js
+++ b/app/lib/models/collection.js
@@ -18,7 +18,6 @@ Collection.prototype.getCollections = function () {
     config
       .get('apis')
       .map(api => {
-
         return new DadiAPI(Object.assign(api, {uri: api.host}))
         .getCollections()
         .then(res => this.getSchemas(api, res.collections))
@@ -30,7 +29,6 @@ Collection.prototype.getSchemas = function (api, collections) {
   return Promise.all(
     collections
       .map(collection => {
-
         return new DadiAPI(Object.assign(api, {uri: api.host}))
           .useDatabase(collection.database)
           .in(collection.slug)

--- a/app/lib/models/collection.js
+++ b/app/lib/models/collection.js
@@ -18,6 +18,7 @@ Collection.prototype.getCollections = function () {
     config
       .get('apis')
       .map(api => {
+
         return new DadiAPI(Object.assign(api, {uri: api.host}))
         .getCollections()
         .then(res => this.getSchemas(api, res.collections))
@@ -29,6 +30,7 @@ Collection.prototype.getSchemas = function (api, collections) {
   return Promise.all(
     collections
       .map(collection => {
+
         return new DadiAPI(Object.assign(api, {uri: api.host}))
           .useDatabase(collection.database)
           .in(collection.slug)

--- a/frontend/containers/DocumentEdit/DocumentEdit.jsx
+++ b/frontend/containers/DocumentEdit/DocumentEdit.jsx
@@ -262,6 +262,7 @@ class DocumentEdit extends Component {
     
     window.removeEventListener('beforeunload', this.userLeavingDocumentHandler)
 
+    this.handleUserLeavingDocument()
     actions.roomChange(null)
   }
 

--- a/frontend/containers/LazyLoader/LazyLoader.jsx
+++ b/frontend/containers/LazyLoader/LazyLoader.jsx
@@ -23,7 +23,7 @@ class LazyLoader extends Component {
   }
 
   static defaultProps = {
-    styles: "",
+    styles: '',
     idleOnly: true
   }
 
@@ -41,7 +41,7 @@ class LazyLoader extends Component {
       src
     } = this.props
     const {status} = this.state
-    const canLoad = this.evalLoadingConditions()
+    const canLoad = this.checkAppStatus()
     const canDisplay = Object.is(status, Constants.STATUS_LOADED)
     const loadFailed = Object.is(status, Constants.STATUS_FAILED)
 
@@ -50,12 +50,16 @@ class LazyLoader extends Component {
     return (
       <img 
         src={src}
-        style={!canDisplay && `display: none`}
+        style={!canDisplay && 'display: none'}
         class={styles}
         onLoad={this.handleImageLoaded.bind(this)}
         onError={this.handleImageError.bind(this)}
       />
     )
+  }
+
+  componentWillUnmount() {
+    this.setState({ status: Constants.STATUS_IDLE })
   }
 
   handleImageLoaded() {
@@ -67,13 +71,11 @@ class LazyLoader extends Component {
   }
   
 
-  evalLoadingConditions() {
+  checkAppStatus() {
     const {idleOnly, state} = this.props
 
     // If an idle status is required and not met, block loading
-    if (idleOnly && state.status !== 'STATUS_IDLE') return false
-
-    return true
+    return !idleOnly || Object.is(state.status, Constants.STATUS_IDLE)
   }
 }
 

--- a/frontend/reducers/document.js
+++ b/frontend/reducers/document.js
@@ -196,7 +196,7 @@ export default function document (state = initialState, action = {}) {
 
     // Document action: user leaving document
     case Types.USER_LEAVING_DOCUMENT:
-      return state
+      return initialState
 
     default:
       return state


### PR DESCRIPTION
This PR addresses an issue with document unload, which causes document data to be cached in state after navigating away. 

To replicate the issue:
- add logging to the `fetchDocument` method in `DocumentEdit`. 
- navigate to a document
- navigate to another view
- navigate back to the same document
- observe that `fetchDocument` is not fired, as the state for `document` remains populated, with an idle status