### PR TITLE
fix: use publicUrl to determine websocket connection

### DIFF
--- a/app/config-schema.js
+++ b/app/config-schema.js
@@ -110,11 +110,6 @@ module.exports = {
   },
   app: {
     availableInFrontend: true,
-    baseUrl: {
-      doc: 'The base URL of the application',
-      format: 'url',
-      default: '127.0.0.1'
-    },
     name: {
       doc: 'The applicaton name',
       format: String,
@@ -200,6 +195,27 @@ module.exports = {
       doc: 'GA Tracking credentials',
       format: String,
       default: ''
+    }
+  },
+  publicUrl: {
+    availableInFrontend: true,
+    host: {
+      doc: 'The host of the URL where the Publish instance can be publicly accessed at',
+      format: '*',
+      default: null,
+      env: 'URL_HOST'
+    },
+    port: {
+      doc: 'The port of the URL where the Publish instance can be publicly accessed at',
+      format: '*',
+      default: null,
+      env: 'URL_PORT'
+    },
+    protocol: {
+      doc: 'The protocol of the URL where the Publish instance can be publicly accessed at',
+      format: 'String',
+      default: 'http',
+      env: 'URL_PROTOCOL'
     }
   },
   server: {

--- a/config/config.development.json.dist
+++ b/config/config.development.json.dist
@@ -1,8 +1,7 @@
 {
   "app": {
     "name": "DADI Publish",
-    "publisher": "Publisher Name",
-    "baseUrl": "http://127.0.0.1"
+    "publisher": "Publisher Name"
   },
   "server": {
     "host": "127.0.0.1",

--- a/config/config.production.json.dist
+++ b/config/config.production.json.dist
@@ -1,8 +1,12 @@
 {
   "app": {
     "name": "DADI Publish",
-    "publisher": "Publisher Name",
-    "baseUrl": "http://127.0.0.1"
+    "publisher": "Publisher Name"
+  },
+  "publicUrl": {
+      "host": "127.0.0.1",
+      "port": 443,
+      "protocol": "https"
   },
   "server": {
     "host": "127.0.0.1",

--- a/config/config.test.json
+++ b/config/config.test.json
@@ -1,8 +1,12 @@
 {
   "app": {
     "name": "DADI Publish Test",
-    "publisher": "DADI",
-    "baseUrl": "http://0.0.0.0"
+    "publisher": "DADI"
+  },
+  "publicUrl": {
+      "host": "127.0.0.1",
+      "port": 443,
+      "protocol": "https"
   },
   "server": {
     "host": "0.0.0.0",

--- a/frontend/containers/App/App.jsx
+++ b/frontend/containers/App/App.jsx
@@ -55,25 +55,27 @@ class App extends Component {
     const {actions, state} = this.props
     const previousState = previousProps.state
     const room = previousState.router.room
+    const conf = state.app.config
+    const prevConf = previousState.app.config
 
     if (
-      (!previousProps.state.app.config && state.app.config) &&
-        state.app.config.server.healthcheck.enabled
+      (!prevConf && conf) &&
+        conf.server.healthcheck.enabled
     ) {
       this.monitor = new ConnectionMonitor()
-        .watch(state.app.config.server.healthcheck.frequency)
+        .watch(conf.server.healthcheck.frequency)
         .registerStatusChangeCallback(actions.setNetworkStatus)
 
-      if (state.app.config.ga.enabled) {
+      if (conf.ga.enabled) {
         this.analytics = new Analytics()
-          .register(state.app.config.ga.trackingId)
+          .register(conf.ga.trackingId)
           .pageview(state.router.locationBeforeTransitions.pathname)
       }
     }
 
     // State change: user has signed in.
     if (
-      previousProps.state.user.status === Constants.STATUS_FAILED &&
+      previousState.user.status === Constants.STATUS_FAILED &&
       state.user.status === Constants.STATUS_LOADED
     ) {
       actions.loadAppConfig()
@@ -83,16 +85,16 @@ class App extends Component {
 
     // State change: user has signed out.
     if (
-      previousProps.state.user.status === Constants.STATUS_LOADED &&
+      previousState.user.status === Constants.STATUS_LOADED &&
       state.user.hasSignedOut
     ) {
       return route('/sign-in')
     }
 
     // State change: app now has config.
-    if (!previousState.app.config && state.app.config) {
+    if (!prevConf && conf) {
       actions.loadApis()
-      this.socket = new Socket(state.app.config.server.port)
+      this.socket = new Socket(conf.publicUrl.port || conf.server.port)
         .on('userListChange', this.handleUserListChange.bind(this))
     }
 

--- a/test/unit/app/lib/controllers/app-config.test.js
+++ b/test/unit/app/lib/controllers/app-config.test.js
@@ -10,8 +10,7 @@ let res
 const expectedConfig = {
   app: {
     name: 'DADI Publish Test',
-    publisher: 'DADI',
-    baseUrl: 'http://0.0.0.0'
+    publisher: 'DADI'
   },
   apis:[{ 
     publishId: null,


### PR DESCRIPTION
Addresses an issue where Publish defaults on the server port, which is inaccurate an non-dependable when running behind a load balancer or proxy.

fixes: https://github.com/dadi/publish/issues/354 