### PR TITLE
Add DADI boot message

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const app = require('./app')
 const colors = require('colors') // eslint-disable-line
 const config = require(paths.config)
+const dadiBoot = require('@dadi/boot')
 const log = require('@dadi/logger')
 const nodeVersion = Number(process.version.match(/^v(\d+\.\d+)/)[1])
 const pkg = require('./package.json')
@@ -10,30 +11,29 @@ const pkg = require('./package.json')
 const Publish = function () {}
 
 Publish.prototype.getStartupMessage = function () {
-  const env = config.get('env')
+  let env = config.get('env')
 
   log.init(config.get('logging'), {}, env)
 
-  let startText = '\n\n'
-
-  startText += '----------------------------\n'
-  startText += '' + config.get('app.name').green + '\n'
-  startText += 'Started \'DADI Publish\'\n'
-  startText += '----------------------------\n'
-  startText += 'Server:      '.green + config.get('server.host') + ':' + config.get('server.port') + '\n'
-  startText += 'Version:     '.green + pkg.version + '\n'
-  startText += 'Node.JS:     '.green + nodeVersion + '\n'
-  startText += 'Environment: '.green + env + '\n'
-  startText += '----------------------------\n'
-
-  startText += '\n\nCopyright ' + String.fromCharCode(169) + ' 2015-' + new Date().getFullYear() + ' DADI+ Limited (https://dadi.tech)'.white + '\n'
-
   if (env !== 'test') {
-    console.log(startText)
+    dadiBoot.started({
+      server: `${config.get('server.host')}:${config.get('server.port')}`,
+      header: {
+        app: `${config.get('app.name')} - ${config.get('app.publisher')}`
+      },
+      body: {
+        'Version': pkg.version,
+        'Node.js': nodeVersion,
+        'Environment': env
+      },
+      footer: {}
+    })
   }
 }
 
 Publish.prototype.run = function () {
+  dadiBoot.start(require('./package.json'))
+
   app.start()
     .then(this.getStartupMessage)
     .catch((err) => {

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ Publish.prototype.getStartupMessage = function () {
     dadiBoot.started({
       server: `${config.get('server.host')}:${config.get('server.port')}`,
       header: {
-        app: `${config.get('app.name')} - ${config.get('app.publisher')}`
+        app: `${config.get('app.name')}${config.get('app.publisher') && config.get('app.publisher') !== '' ? ' - ' + config.get('app.publisher') : ''}`
       },
       body: {
         'Version': pkg.version,

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "@dadi/api-wrapper": "^1.4.0",
     "@dadi/api-wrapper-core": "^1.6.0",
+    "@dadi/boot": "^1.1.4",
     "@dadi/logger": "^1.2.0",
     "@dadi/passport": "^1.2.0",
     "@dadi/preact-router": "^2.6.1",


### PR DESCRIPTION
This PR adds a boot message using the @dadi/boot module. Looks a bit like this:

```
⠋ Starting @dadi/publish...
✔ Started @dadi/publish
@ 127.0.0.1:9999

  ┌──────────────────────────────────────────┐
  │ DADI Publish - Publisher Name            │
  ┌──────────────┬───────────────────────────┐
  │ Version      │ 1.0.5-beta                │
  │ Node.js      │ 8.9                       │
  │ Environment  │ development               │
  └──────────────┴───────────────────────────┘


  ℹ Documentation at https://docs.dadi.cloud
  ℹ <CTRL> + C to shut down


   ▓▓▓▓▓  ▓▓▓▓▓▓▓
               ▓▓▓▓
      ▓▓▓▓▓▓▓    ▓▓▓▓
               ▓▓▓▓
          ▓▓▓▓▓▓▓


  © 2018 DADI+ Limited (https://dadi.cloud)
  All rights reserved.


```