### PR TITLE
Ensure document is saved on first attempt

### DIFF
--- a/frontend/containers/DocumentEditToolbar/DocumentEditToolbar.jsx
+++ b/frontend/containers/DocumentEditToolbar/DocumentEditToolbar.jsx
@@ -455,12 +455,12 @@ class DocumentEditToolbar extends Component {
       state
     } = this.props
     const creatingNew = this.onSave && this.onSave.createNew
-    const validationErrors = state.document.validationErrors
-    const hasValidationErrors = !validationErrors || Object.keys(validationErrors)
+    const {hasBeenValidated, validationErrors} = state.document
+    const hasValidationErrors = validationErrors && Object.keys(validationErrors)
       .filter(field => validationErrors[field])
       .length
 
-    if (hasValidationErrors) return
+    if (!hasBeenValidated || hasValidationErrors) return
 
     let document = state.document.local
 

--- a/frontend/reducers/document.js
+++ b/frontend/reducers/document.js
@@ -25,6 +25,7 @@ export default function document (state = initialState, action = {}) {
     case Types.ATTEMPT_SAVE_DOCUMENT:
       return {
         ...state,
+        hasBeenValidated: true,
         saveAttempts: state.saveAttempts + 1
       }
 


### PR DESCRIPTION
There is an issue where a document isn't saved on the first attempt. The issue can be replicated with these steps:

1. Sign in
2. Navigate to a collection (e.g. *Articles*)
3. Navigate to a document
4. Click "Save and continue"
5. Observe that no notification has been shown indicating that the document has been saved
6. Click "Save and continue" again
7. Observe that the notification has been shown this time

This PR fixes that.