### PR TITLE
allow string fields to be links

### DIFF
--- a/frontend/components/FieldString/FieldString.css
+++ b/frontend/components/FieldString/FieldString.css
@@ -31,4 +31,5 @@
 .link-preview {
   width: 100%;
   margin-top: 5px;
+  margin-bottom: 5px;
 }

--- a/frontend/components/FieldString/FieldString.css
+++ b/frontend/components/FieldString/FieldString.css
@@ -27,3 +27,8 @@
 .dropdown-option:first-of-type {
   padding-top: 6px;
 }
+
+.link-preview {
+  width: 100%;
+  margin-top: 5px;
+}

--- a/frontend/components/FieldString/FieldStringEdit.jsx
+++ b/frontend/components/FieldString/FieldStringEdit.jsx
@@ -296,10 +296,9 @@ export default class FieldStringEdit extends Component {
       error,
       placeholder,
       required,
-      schema
+      schema,
+      value
     } = this.props
-    let {value} = this.props
-
     const {hasFocus} = this.state
     const publishBlock = schema.publish || {}
     const {heightType, rows, resizable} = publishBlock

--- a/frontend/components/FieldString/FieldStringEdit.jsx
+++ b/frontend/components/FieldString/FieldStringEdit.jsx
@@ -307,6 +307,7 @@ export default class FieldStringEdit extends Component {
 
     let link = publishBlock.display && publishBlock.display.link
     let linkFormatted = false
+
     if (link && typeof link === 'string') {
       linkFormatted = link.replace(/{value}/, value)
     }

--- a/frontend/components/FieldString/FieldStringEdit.jsx
+++ b/frontend/components/FieldString/FieldStringEdit.jsx
@@ -307,7 +307,7 @@ export default class FieldStringEdit extends Component {
 
     let link = publishBlock.display && publishBlock.display.link
     let linkFormatted = false
-    if (link && typeof link  === 'string') {
+    if (link && typeof link === 'string') {
       linkFormatted = link.replace(/{value}/, value)
     }
 

--- a/frontend/components/FieldString/FieldStringEdit.jsx
+++ b/frontend/components/FieldString/FieldStringEdit.jsx
@@ -6,6 +6,7 @@ import proptypes from 'proptypes'
 import Style from 'lib/Style'
 import styles from './FieldString.css'
 
+import Button from 'components/Button/Button'
 import Label from 'components/Label/Label'
 import RichEditor from 'components/RichEditor/RichEditor'
 import TextInput from 'components/TextInput/TextInput'
@@ -295,14 +296,21 @@ export default class FieldStringEdit extends Component {
       error,
       placeholder,
       required,
-      schema,
-      value
+      schema
     } = this.props
+    let {value} = this.props
+
     const {hasFocus} = this.state
     const publishBlock = schema.publish || {}
     const {heightType, rows, resizable} = publishBlock
     const type = publishBlock.multiline ? 'multiline' : 'text'
     const readOnly = publishBlock.readonly === true
+
+    let link = publishBlock.display && publishBlock.display.link
+    let linkFormatted = false
+    if (link && typeof link  === 'string') {
+      linkFormatted = link.replace(/{value}/, value)
+    }
 
     return (
       <Label
@@ -325,6 +333,14 @@ export default class FieldStringEdit extends Component {
           type={type}
           value={value}
         />
+        {link && (
+          <Button
+            accent="neutral"
+            size="small"
+            href={linkFormatted || value} 
+            className={styles['link-preview']}
+          >Open in new window</Button>
+        )}
       </Label>
     )
   }

--- a/frontend/components/FieldString/FieldStringList.jsx
+++ b/frontend/components/FieldString/FieldStringList.jsx
@@ -95,7 +95,7 @@ export default class FieldStringList extends Component {
         .replace(/(^\w+:|^)\/\//, '')
         .replace(/\/$/, '')
 
-    if (typeof template  === 'string') {
+    if (typeof template === 'string') {
       value = template.replace(/{value}/, value)
     }
 

--- a/frontend/components/FieldString/FieldStringList.jsx
+++ b/frontend/components/FieldString/FieldStringList.jsx
@@ -35,6 +35,11 @@ export default class FieldStringList extends Component {
       return this.renderOptions(value, schema)
     }
 
+    // If it is a link field
+    if (schema.publish && schema.publish.display && schema.publish.display.link) {
+      return this.renderLinkValue(value, schema.publish.display.link)
+    }
+
     // If there's an options block, we render the label of the given option.
     if (schema.publish && schema.publish.options) {
       return this.renderOptions([value], schema)
@@ -77,10 +82,25 @@ export default class FieldStringList extends Component {
   renderTrimmedValue(value, maxLength) {
     maxLength = Math.floor(maxLength) || this.props.maxLength
 
-    /*if (value.length > maxLength) {
+    if (value.length > maxLength) {
       return value.slice(0, maxLength - 1).trim() + '…'
-    }*/
+    }
 
     return value
+  }
+
+  renderLinkValue(value, template) {
+    let valueFormatted = 
+      value
+        .replace(/(^\w+:|^)\/\//, '')
+        .replace(/\/$/, '')
+
+    if (typeof template  === 'string') {
+      value = template.replace(/{value}/, value)
+    }
+
+    return (
+      <a href={value} target="_blank">{valueFormatted}</a>
+    )
   }
 }


### PR DESCRIPTION
Turns string fields into links for inside the Publish interface, both in the edit view and list view. Useful for external services.

Closes #477 

Example schema (team collection on dadi.cloud)

```json
"twitter": {
  "type": "String",
  "required": false,
  "label": "Twitter",
  "publish": {
    "section": "Details",
    "placement": "sidebar",
    "display": {
      "edit": true,
      "list": true,
      "link": "https://twitter.com/{value}"
    }
  }
},
"linkedIn": {
  "type": "String",
  "required": false,
  "label": "LinkedIn",
  "publish": {
    "section": "Details",
    "placement": "sidebar",
    "display": {
      "edit": true,
      "list": true,
      "link": "https://linkedin.com/in/{value}"
    }
  }
},
"personalSite": {
  "type": "String",
  "required": false,
  "label": "Personal site",
  "publish": {
    "section": "Details",
    "placement": "sidebar",
    "display": {
      "edit": true,
      "list": true,
      "link": true
    }
  }
}
```