### PR TITLE
first string field takes preference as document link

### DIFF
--- a/frontend/containers/DocumentList/DocumentList.jsx
+++ b/frontend/containers/DocumentList/DocumentList.jsx
@@ -295,7 +295,14 @@ class DocumentList extends Component {
     let fieldSchema = collection.fields[column.id]
     let renderedValue = this.renderField(column.id, fieldSchema, value)
 
-    if (index === 0) {
+    let firstStringField = Object.keys(collection.fields).filter(i => {
+      return collection.fields[i].type === 'String'
+    })[0]
+
+    if (
+      (firstStringField && firstStringField === column.id) || 
+      (!firstStringField && index === 0)
+    ) {
       return (
         <a href={editLink}>{renderedValue}</a>
       )

--- a/frontend/containers/DocumentList/DocumentList.jsx
+++ b/frontend/containers/DocumentList/DocumentList.jsx
@@ -295,7 +295,7 @@ class DocumentList extends Component {
     let fieldSchema = collection.fields[column.id]
     let renderedValue = this.renderField(column.id, fieldSchema, value)
 
-    let firstStringField = Object.keys(collection.fields).filter(i => {
+    let firstStringField = Object.keys(collection.fields).filter(field => {
       return collection.fields[i].type === 'String'
     })[0]
 

--- a/frontend/containers/DocumentList/DocumentList.jsx
+++ b/frontend/containers/DocumentList/DocumentList.jsx
@@ -296,7 +296,7 @@ class DocumentList extends Component {
     let renderedValue = this.renderField(column.id, fieldSchema, value)
 
     let firstStringField = Object.keys(collection.fields).filter(field => {
-      return collection.fields[i].type === 'String'
+      return collection.fields[field].type === 'String'
     })[0]
 
     if (


### PR DESCRIPTION
This PR addresses a small issue if you set a `Reference` field or `Media` field as the first displayed field in your API schema you are unable to click through from the list view (both those fields override the link).

It finds the first field of type `String` and appends the document link to that value, even if it's not in position `0`. If there are no `String` fields in the schema, it fallsback to position `0`