### PR TITLE
Stop notification from obstructing full width

### DIFF
--- a/frontend/components/Notification/Notification.css
+++ b/frontend/components/Notification/Notification.css
@@ -1,9 +1,8 @@
 .container {
   position: fixed;
-  left: 0;
+  left: 50%;
   top: 0;
   text-align: center;
-  width: 100%;
   opacity: 0;
   transform: translateY(-100%);
   transition: all 0.2s ease-out;
@@ -16,6 +15,8 @@
 }
 
 .notification {
+  position: relative;
+  left: -50%;
   display: inline-block;
   line-height: 1.25;
   font-family: var(--theme-font-family, sans-serif);


### PR DESCRIPTION
Currently, notifications take up the full viewport width, meaning that it's impossible to click on any elements on the same horizontal position, even if they are not directly obstructed by the notification.

This PR fixes that.

<img width="1762" alt="screenshot 2018-11-20 at 12 59 50" src="https://user-images.githubusercontent.com/4162329/48775208-4a5aa600-ecc4-11e8-8257-afd2ff725989.png">
