### PR TITLE
Handle Return key on code block + remove paragraph from list items

### DIFF
--- a/frontend/components/RichEditor/RichEditor.css
+++ b/frontend/components/RichEditor/RichEditor.css
@@ -300,6 +300,10 @@
   list-style-position: inside;  
 }
 
+.editor-wysiwyg li p {
+  display: inline;
+}
+
 .editor-wysiwyg [data-publish-link-edit] {
   background-color: #f3f8ff;
 }

--- a/frontend/components/RichEditor/RichEditor.jsx
+++ b/frontend/components/RichEditor/RichEditor.jsx
@@ -97,7 +97,12 @@ export default class RichEditor extends Component {
     this.turndownService.addRule('li', {
       filter: ['li'],
       replacement: (content, node) => {
-        return `* ${content && content.trim()}\n`
+        let parent = node.parentNode
+        let listCharacter = node.parentNode.tagName === 'OL' ?
+          '1.' :
+          '*'
+
+        return `${listCharacter} ${content && content.trim()}\n`
       }
     })
 
@@ -112,10 +117,9 @@ export default class RichEditor extends Component {
 
         return '```' + language + '\n' + content + '\n```'
       }
-    })    
+    })
 
     this.markdownRenderer = new marked.Renderer()
-
     this.markdownRenderer.code = (code, language = '') => {
       let escapedCode = code
          .replace(/&/g, '&amp;')
@@ -439,7 +443,9 @@ export default class RichEditor extends Component {
         anchorOffset: position
       } = window.getSelection()
       let text = anchorNode.textContent
-      let newText = `${text.slice(0, position)}\n${text.slice(position)}`
+      let leftPart = text.slice(0, position)
+      let rightPart = text.slice(position)
+      let newText = `${leftPart}\n${rightPart}${rightPart === '' ? '\n' : ''}`
 
       anchorNode.textContent = newText
 

--- a/frontend/components/RichEditor/RichEditor.jsx
+++ b/frontend/components/RichEditor/RichEditor.jsx
@@ -94,6 +94,13 @@ export default class RichEditor extends Component {
       headingStyle: 'atx'
     })
 
+    this.turndownService.addRule('li', {
+      filter: ['li'],
+      replacement: (content, node) => {
+        return `* ${content && content.trim()}\n`
+      }
+    })
+
     this.turndownService.addRule('pre', {
       filter: (node, options) => {
         return node.classList.contains(styles.code)

--- a/frontend/lib/local-storage.js
+++ b/frontend/lib/local-storage.js
@@ -6,6 +6,10 @@ function clear (key) {
   try {
     window.localStorage.removeItem(key)
 
+    if (process.env.NODE_ENV === 'development') {
+      console.log('Removing key from local storage:', key)
+    }
+
     return true
   } catch (err) {
     return false


### PR DESCRIPTION
This PR handles the Return key on code blocks, preventing a new block from being created. Additionally, it also fixes an issue where the "Unsaved changes" dialog was being shown unnecessarily.

Closes #561.
Closes #620.