### PR TITLE
Various fixes

### DIFF
--- a/frontend/actions/apiActions.js
+++ b/frontend/actions/apiActions.js
@@ -113,7 +113,6 @@ const applyDefaultPublishParams = fields => {
       field.publish = field.publish || defaultPublishBlock
       field.publish.section = field.publish.section || defaultPublishBlock.section
       field.publish.placement = field.publish.placement || defaultPublishBlock.placement
-      field.publish.display = field.publish.display || defaultPublishBlock.display
 
       return {
         [key]: field

--- a/frontend/actions/documentActions.js
+++ b/frontend/actions/documentActions.js
@@ -271,7 +271,10 @@ export function saveDocument ({
       }).catch(response => {
         if (response.errors && response.errors.length) {
           dispatch(
-            setErrorsFromRemoteAPI(response.errors)
+            batchActions([
+              setErrorsFromRemoteAPI(response.errors),
+              setRemoteDocumentStatus(Constants.STATUS_IDLE)
+            ])
           )
         } else {
           dispatch(

--- a/frontend/actions/documentActions.js
+++ b/frontend/actions/documentActions.js
@@ -4,6 +4,7 @@ import * as LocalStorage from 'lib/local-storage'
 import * as Types from 'actions/actionTypes'
 import * as userActions from 'actions/userActions'
 import {batchActions} from 'lib/redux'
+import {uploadMedia} from 'actions/documentsActions'
 import apiBridgeClient from 'lib/api-bridge-client'
 
 export function clearRemoteDocument () {
@@ -190,153 +191,83 @@ export function saveDocument ({
       })
     }
 
-    // Handling reference fields.
-    let referenceQueue = []
-    let referenceQueueMap = []
+    // Handling Reference and Media fields.
+    let referenceQueue = Object.keys(payload).map(field => {
+      let schema = collection.fields[field]
 
-    // We iterate through the payload and find reference fields.
-    Object.keys(payload).forEach(field => {
-      const fieldSchema = collection.fields[field]
+      // We're only interested in fields that have an entry in the collection
+      // schema, have a truthy value in the document and are of type Reference
+      // or Media.
+      if (
+        !schema ||
+        !payload[field] ||
+        !['Media', 'Reference'].includes(schema.type)
+      ) {
+        return
+      }
 
-      if (!fieldSchema) return
+      let schemaSettings = schema.settings || {}
+      let referencedDocuments = Array.isArray(payload[field]) ?
+          payload[field] :
+          [payload[field]]
+      let referenceLimit = (
+        schemaSettings.limit !== undefined &&
+        schemaSettings.limit > 0
+      ) ? schemaSettings.limit : Infinity
+      let isMediaReference = schema.type === 'Reference' &&
+        schemaSettings.collection === Constants.MEDIA_COLLECTION
+      let isMedia = schema.type === 'Media'
 
-      const referencedCollection = fieldSchema.settings && fieldSchema.settings.collection
+      if (isMediaReference || isMedia) {
+        return uploadMedia({
+          api,
+          bearerToken: getState().user.accessToken,
+          files: referencedDocuments.map(document => document._file)
+        }).then(({results}) => {
+          if (isMediaReference) {
+            return results.map(result => result._id)
+          }
 
-      // We're only interested in the field if its value is truthy. If it's
-      // null, it's good as it is.
-      if (payload[field] && fieldSchema.type === 'Reference') {
-        const referencedDocument = payload[field]
-        const referencedDocuments = Array.isArray(referencedDocument) ?
-            referencedDocument : [referencedDocument]
-        const referenceLimit = (
-          fieldSchema.settings &&
-          fieldSchema.settings.limit !== undefined &&
-          fieldSchema.settings.limit > 0
-        ) ? fieldSchema.settings.limit : Infinity
+          return results.map(result => ({
+            _id: result._id
+          }))
+        }).then(reference => {
+          payload[field] = referenceLimit > 1 ? reference : reference[0]
+        })
+      } else {
+        let reference = referencedDocuments
+          .map(document => document._id)
+          .filter(Boolean)
 
-        // Is this a reference to a media collection?
-        if (referencedCollection === Constants.MEDIA_COLLECTION) {
-          payload[field] = referencedDocuments.map((document, index) => {
-            // If this is an existing media item, we simply grab its ID.
-            if (document._id) {
-              return document._id
-            }
-
-            // Otherwise, we need to upload the file.
-            referenceQueue.push(
-              apiBridgeClient({
-                accessToken: getState().user.accessToken,
-                api
-              }).inMedia().getSignedUrl({
-                contentLength: document.contentLength,
-                fileName: document.fileName,
-                mimetype: document.mimetype
-              })
-            )
-
-            referenceQueueMap.push({
-              field,
-              index,
-              mediaUpload: true
-            })
-
-            return document
-          })
-        } else {
-          const referencedCollectionSchema = referencedCollection &&
-            api.collections.find(collection => {
-              return collection.slug === referencedCollection
-            })
-
-          // If the referenced collection doesn't exist, there's nothing we can do.
-          if (!referencedCollectionSchema) return
-
-          let referenceDocumentIds = []
-
-          referencedDocuments.forEach(document => {
-            // The document already exists, we need to update it.
-            if (document._id) {
-              referenceDocumentIds.push(document._id)
-            } else {
-
-              // The document does not exist, we need to create it.
-            }
-          })
-
-          payload[field] = referenceLimit > 1 ? referenceDocumentIds : referenceDocumentIds[0]
-        }
+        payload[field] = referenceLimit > 1 ? reference : reference[0]
       }
     })
 
-    Promise.all(referenceQueue).then(responses => {
-      let uploadQueue = []
+    Promise.all(referenceQueue).then(() => {
+      apiBridge = isUpdate ?
+        apiBridge.update(payload) :
+        apiBridge.create(payload)
 
-      // `responses` contains an array of API responses resulting from updating
-      // or creationg referenced documents. The names of the fields they relate
-      // to are defined in `referenceQueueMap`.
-      responses.forEach((response, index) => {
-        const queueMapEntry = referenceQueueMap[index]
-        const referenceField = queueMapEntry.field
-        const referenceLimit = queueMapEntry.limit
+      return apiBridge.then(response => {
+        if (response.results && response.results.length) {
+          dispatch(setRemoteDocument(response.results[0], {
+            clearLocal: true,
+            forceUpdate: true
+          }))
 
-        // If this bundle entry is a media upload, we're not done yet. The
-        // bundle response gave us a signed URL, but we still need to upload
-        // the file and add the resulting ID to the final payload.
-        if (queueMapEntry.mediaUpload) {
-          dispatch(
-            setRemoteDocumentStatus(Constants.STATUS_SAVING)
-          )
+          // We've successfully saved the document, so we now need to clear
+          // the local storage key corresponding to the unsaved document for
+          // the given collection path.
+          const localStorageKey = isUpdate ?
+            documentId :
+            collection.path
 
-          const mediaUpload = uploadMediaToSignedURL(
-            api,
-            response.url,
-            payload[referenceField][queueMapEntry.index]
-          ).then(uploadResponse => {
-            if (uploadResponse.results && uploadResponse.results.length) {
-              payload[referenceField][queueMapEntry.index] = uploadResponse.results[0]._id
-            }
-          })
-
-          uploadQueue.push(mediaUpload)
-        } else if (response.results) {
-          payload[referenceField] = referenceLimit === 1 ?
-            response.results[0]._id :
-            payload[referenceField].concat(response.results.map(document => {
-              return document._id
-            }))
-        }
-      })
-
-      // Wait for any media uploads to be finished.
-      return Promise.all(uploadQueue).then(() => {
-        // The payload is ready, we can attach it to API Bridge.
-        if (isUpdate) {
-          apiBridge = apiBridge.update(payload)
+          LocalStorage.clearDocument(localStorageKey)
         } else {
-          apiBridge = apiBridge.create(payload)
+          dispatch(
+            setRemoteDocumentStatus(Constants.STATUS_FAILED)
+          )
         }
-
-        return apiBridge.then(response => {
-          if (response.results && response.results.length) {
-            dispatch(setRemoteDocument(response.results[0], {
-              clearLocal: true,
-              forceUpdate: true
-            }))
-
-            // We've successfully saved the document, so we now need to clear
-            // the local storage key corresponding to the unsaved document for
-            // the given collection path.
-            const localStorageKey = isUpdate ?
-              documentId :
-              collection.path
-
-            LocalStorage.clearDocument(localStorageKey)
-          } else {
-            dispatch(
-              setRemoteDocumentStatus(Constants.STATUS_FAILED)
-            )
-          }
-        })
       }).catch(response => {
         if (response.errors && response.errors.length) {
           dispatch(

--- a/frontend/actions/documentsActions.js
+++ b/frontend/actions/documentsActions.js
@@ -78,6 +78,7 @@ export function fetchDocuments ({
   api,
   collection,
   count,
+  fields,
   filters,
   page,
   parentDocumentId,
@@ -134,8 +135,6 @@ export function fetchDocuments ({
           api
         }).inMedia()
       } else {
-        const fields = visibleFieldList({fields: collection.fields, view: 'list'})
-
         listQuery = apiBridgeClient({
           accessToken: getState().user.accessToken,
           api,

--- a/frontend/actions/documentsActions.js
+++ b/frontend/actions/documentsActions.js
@@ -194,7 +194,7 @@ export function setDocumentListStatus (status, data) {
   }
 }
 
-export function uploadMedia ({
+export function saveMediaDocuments ({
   api,
   files
 }) {
@@ -203,21 +203,12 @@ export function uploadMedia ({
       setDocumentListStatus(Constants.STATUS_SAVING)
     )
 
-    let bearerToken = getState().user.accessToken
-    let url = `${api.host}:${api.port}/media/upload`
-    let body = new FormData()
-
-    files.forEach((file, index) => {
-      body.append(`file${index}`, file)
+    uploadMedia({
+      api,
+      bearerToken: getState().user.accessToken,
+      files
     })
-
-    fetch(url, {
-      body,
-      headers: {
-        Authorization: `Bearer ${bearerToken}`
-      },
-      method: 'POST'
-    }).then(response => response.json()).then(response => {
+    .then(response => {
       dispatch(
         setDocumentListStatus(Constants.STATUS_IDLE)
       )
@@ -228,4 +219,25 @@ export function uploadMedia ({
       )
     })
   }
+}
+
+export function uploadMedia ({
+  api,
+  bearerToken,
+  files
+}) {
+  let url = `${api.host}:${api.port}/media/upload`
+  let body = new FormData()
+
+  files.forEach((file, index) => {
+    body.append(`file${index}`, file)
+  })
+
+  return fetch(url, {
+    body,
+    headers: {
+      Authorization: `Bearer ${bearerToken}`
+    },
+    method: 'POST'
+  }).then(response => response.json())
 }

--- a/frontend/components/ColorPicker/ColorPicker.jsx
+++ b/frontend/components/ColorPicker/ColorPicker.jsx
@@ -76,12 +76,20 @@ export default class ColorPicker extends Component {
     this.elementHue.addEventListener('mouseup', this.handleStopSettingHue)
     this.elementHue.addEventListener('mouseout', this.handleStopSettingHue)
     this.elementHue.addEventListener('mousemove', this.handleProcessHue)
+    this.elementHue.addEventListener('touchstart', this.handleStartSettingHue)
+    this.elementHue.addEventListener('touchend', this.handleStopSettingHue)
+    this.elementHue.addEventListener('touchcancel', this.handleStopSettingHue)
+    this.elementHue.addEventListener('touchmove', this.handleProcessHue)
 
     // Attach palette events.
     this.elementPalette.addEventListener('mousedown', this.handleStartSettingPalette)
     this.elementPalette.addEventListener('mouseup', this.handleStopSettingPalette)
     this.elementPalette.addEventListener('mouseout', this.handleStopSettingPalette)
     this.elementPalette.addEventListener('mousemove', this.handleProcessPalette)
+    this.elementPalette.addEventListener('touchstart', this.handleStartSettingPalette)
+    this.elementPalette.addEventListener('touchend', this.handleStopSettingPalette)
+    this.elementPalette.addEventListener('touchcancel', this.handleStopSettingPalette)
+    this.elementPalette.addEventListener('touchmove', this.handleProcessPalette)
   }
 
   componentWillUnmount() {
@@ -90,12 +98,20 @@ export default class ColorPicker extends Component {
     this.elementHue.removeEventListener('mouseup', this.handleStopSettingHue)
     this.elementHue.removeEventListener('mouseout', this.handleStopSettingHue)
     this.elementHue.removeEventListener('mousemove', this.handleProcessHue)
+    this.elementHue.removeEventListener('touchstart', this.handleStartSettingHue)
+    this.elementHue.removeEventListener('touchend', this.handleStopSettingHue)
+    this.elementHue.removeEventListener('touchcancel', this.handleStopSettingHue)
+    this.elementHue.removeEventListener('touchmove', this.handleProcessHue)
 
     // Remove palette events.
     this.elementPalette.removeEventListener('mousedown', this.handleStartSettingPalette)
     this.elementPalette.removeEventListener('mouseup', this.handleStopSettingPalette)
     this.elementPalette.removeEventListener('mouseout', this.handleStopSettingPalette)
     this.elementPalette.removeEventListener('mousemove', this.handleProcessPalette)
+    this.elementPalette.removeEventListener('touchstart', this.handleStartSettingPalette)
+    this.elementPalette.removeEventListener('touchend', this.handleStopSettingPalette)
+    this.elementPalette.removeEventListener('touchcancel', this.handleStopSettingPalette)
+    this.elementPalette.removeEventListener('touchmove', this.handleProcessPalette)
   }
 
   handleHueChange(event) {

--- a/frontend/components/FieldMedia/FieldMediaEdit.jsx
+++ b/frontend/components/FieldMedia/FieldMediaEdit.jsx
@@ -254,6 +254,8 @@ export default class FieldMediaEdit extends Component {
     const isReference = schema.type === 'Reference'
     const singleFile = schema.settings && schema.settings.limit === 1
     const values = (value && !Array.isArray(value)) ? [value] : value
+    const isReadOnly = schema.publish &&
+      schema.publish.readonly === true
     const errorMessage = isInvalidMimeType &&
       `Files must be of type ${acceptedMimeTypes.join(', ')}`
     const comment = schema.comment ||
@@ -310,42 +312,44 @@ export default class FieldMediaEdit extends Component {
           </div>
         )}
 
-        <div class={styles.upload}>
-          <div class={styles['upload-options']}>
-            <DropArea
-              accept={acceptedMimeTypes}
-              draggingText={`Drop file${singleFile ? '' : 's'} here`}
-              onDrop={this.handleFileChange.bind(this)}
-            >
-              <div class={styles['upload-drop']}>
-                Drop file{singleFile ? '' : 's'} to upload
-              </div>
-            </DropArea>
-          </div>
+        {!isReadOnly &&
+          <div class={styles.upload}>
+            <div class={styles['upload-options']}>
+              <DropArea
+                accept={acceptedMimeTypes}
+                draggingText={`Drop file${singleFile ? '' : 's'} here`}
+                onDrop={this.handleFileChange.bind(this)}
+              >
+                <div class={styles['upload-drop']}>
+                  Drop file{singleFile ? '' : 's'} to upload
+                </div>
+              </DropArea>
+            </div>
 
-          <div class={styles.placeholder}>
-            <Button
-              accent="neutral"
-              size="small"
-              href={href}
-            >Select existing {fieldLocalType.toLowerCase()}</Button>
-          </div>
-
-          <div class={styles.placeholder}>
-            <FileUpload
-              accept={acceptedMimeTypes}
-              multiple={!singleFile}
-              onChange={this.handleFileChange.bind(this)}
-            >
+            <div class={styles.placeholder}>
               <Button
                 accent="neutral"
-                className={styles['upload-select']}
                 size="small"
-                type="mock-stateful"
-              >Select from device</Button>            
-            </FileUpload>
+                href={href}
+              >Select existing {fieldLocalType.toLowerCase()}</Button>
+            </div>
+
+            <div class={styles.placeholder}>
+              <FileUpload
+                accept={acceptedMimeTypes}
+                multiple={!singleFile}
+                onChange={this.handleFileChange.bind(this)}
+              >
+                <Button
+                  accent="neutral"
+                  className={styles['upload-select']}
+                  size="small"
+                  type="mock-stateful"
+                >Select from device</Button>
+              </FileUpload>
+            </div>
           </div>
-        </div>
+        }
       </Label>
     )
   }

--- a/frontend/components/FieldMedia/FieldMediaEdit.jsx
+++ b/frontend/components/FieldMedia/FieldMediaEdit.jsx
@@ -119,6 +119,25 @@ export default class FieldMediaEdit extends Component {
     this.state.isInvalidMimeType = false
   }
 
+  componentDidMount() {
+    const {forceValidation, value} = this.props
+
+    if (forceValidation) {
+      this.validate(value)
+    }
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    const {forceValidation, value} = this.props
+
+    if (
+      !prevProps.forceValidation && forceValidation ||
+      !prevProps.value && value
+    ) {
+      this.validate(value)
+    }
+  }
+
   handleFileChange(files) {
     const {
       config,
@@ -216,9 +235,11 @@ export default class FieldMediaEdit extends Component {
       config = {},
       displayName,
       documentId,
+      error,
       group,
       name,
       onBuildBaseUrl,
+      required,
       schema,
       value
     } = this.props
@@ -235,11 +256,15 @@ export default class FieldMediaEdit extends Component {
     const values = (value && !Array.isArray(value)) ? [value] : value
     const errorMessage = isInvalidMimeType &&
       `Files must be of type ${acceptedMimeTypes.join(', ')}`
+    const comment = schema.comment ||
+      required && 'Required' ||
+      isReadOnly && 'Read only'
 
     return (
       <Label
         className={styles.label}
-        error={isInvalidMimeType}
+        comment={comment}
+        error={error || isInvalidMimeType}
         errorMessage={errorMessage}
         label={displayName}
       >
@@ -323,5 +348,14 @@ export default class FieldMediaEdit extends Component {
         </div>
       </Label>
     )
+  }
+
+  validate(value) {
+    const {name, onError, required} = this.props
+    const hasValidationErrors = required && !value
+
+    if (typeof onError === 'function') {
+      onError.call(this, name, hasValidationErrors, value)
+    }    
   }
 }

--- a/frontend/components/FieldMedia/FieldMediaItem.jsx
+++ b/frontend/components/FieldMedia/FieldMediaItem.jsx
@@ -23,7 +23,7 @@ export default class FieldMediaItem extends Component {
     value: proptypes.object
   }
 
-  getSource() {
+  render() {
     const {config, isList, value} = this.props
     const cdn = config ? config.cdn : null
 
@@ -80,9 +80,5 @@ export default class FieldMediaItem extends Component {
         </a>
       </div>
     )
-  }
-
-  render() {
-    return this.getSource()
   }
 }

--- a/frontend/components/FieldReference/FieldReferenceEdit.jsx
+++ b/frontend/components/FieldReference/FieldReferenceEdit.jsx
@@ -112,7 +112,10 @@ export default class FieldReferenceEdit extends Component {
   componentDidUpdate(prevProps, prevState) {
     const {forceValidation, value} = this.props
 
-    if (!prevProps.forceValidation && forceValidation) {
+    if (
+      !prevProps.forceValidation && forceValidation ||
+      !prevProps.value && value
+    ) {
       this.validate(value)
     }
   }
@@ -145,6 +148,7 @@ export default class FieldReferenceEdit extends Component {
       onBuildBaseUrl,
       onChange,
       onError,
+      required,
       schema,
       value
     } = this.props
@@ -171,12 +175,15 @@ export default class FieldReferenceEdit extends Component {
     const values = value && !(value instanceof Array) ? [value] : value
     const publishBlock = schema.publish || {}
     const isReadOnly = publishBlock.readonly === true
+    const comment = schema.comment ||
+      required && 'Required' ||
+      isReadOnly && 'Read only'
 
     return (
       <Label
+        comment={comment}
         error={error}
         label={displayName}
-        comment={isReadOnly && 'Read only'}
       >
         {value && (
           <div class={styles['value-container']}>

--- a/frontend/components/FieldReference/FieldReferenceEdit.jsx
+++ b/frontend/components/FieldReference/FieldReferenceEdit.jsx
@@ -101,10 +101,34 @@ export default class FieldReferenceEdit extends Component {
     value: proptypes.bool
   }
 
+  componentDidMount() {
+    const {forceValidation, value} = this.props
+
+    if (forceValidation) {
+      this.validate(value)
+    }
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    const {forceValidation, value} = this.props
+
+    if (!prevProps.forceValidation && forceValidation) {
+      this.validate(value)
+    }
+  }
+
   findFirstStringField(fields) {
     return Object.keys(fields)
       .map(key => Object.assign({}, fields[key], {key}))
       .find(field => field.type === 'String')
+  }
+
+  handleRemove() {
+    const {name, onChange, schema} = this.props
+
+    if (typeof onChange === 'function') {
+      onChange.call(this, name, null)
+    }
   }
 
   render() {
@@ -150,6 +174,7 @@ export default class FieldReferenceEdit extends Component {
 
     return (
       <Label
+        error={error}
         label={displayName}
         comment={isReadOnly && 'Read only'}
       >
@@ -222,11 +247,12 @@ export default class FieldReferenceEdit extends Component {
     )
   }
 
-  handleRemove() {
-    const {name, onChange, schema} = this.props
+  validate(value) {
+    const {name, onError, required} = this.props
+    const hasValidationErrors = required && !value
 
-    if (typeof onChange === 'function') {
-      onChange.call(this, name, null)
-    }
+    if (typeof onError === 'function') {
+      onError.call(this, name, hasValidationErrors, value)
+    }    
   }
 }

--- a/frontend/components/FieldReference/FieldReferenceEdit.jsx
+++ b/frontend/components/FieldReference/FieldReferenceEdit.jsx
@@ -3,7 +3,7 @@
 import {h, Component} from 'preact'
 import proptypes from 'proptypes'
 import {buildUrl} from 'lib/router'
-import {filterVisibleFields} from 'lib/fields'
+import {getVisibleFields} from 'lib/fields'
 
 import Style from 'lib/Style'
 import styles from './FieldReference.css'
@@ -134,9 +134,9 @@ export default class FieldReferenceEdit extends Component {
 
     if (!referencedCollection) return null
 
-    const displayableFields = filterVisibleFields({
+    const displayableFields = getVisibleFields({
       fields: referencedCollection.fields,
-      view: 'list'
+      viewType: 'list'
     })
     const firstStringField = this.findFirstStringField(displayableFields)
     const displayField = value && firstStringField ? firstStringField.key : null

--- a/frontend/components/FieldReference/FieldReferenceList.jsx
+++ b/frontend/components/FieldReference/FieldReferenceList.jsx
@@ -2,7 +2,7 @@
 
 import {h, Component} from 'preact'
 import proptypes from 'proptypes'
-import {filterVisibleFields} from 'lib/fields'
+import {getVisibleFields} from 'lib/fields'
 
 import Style from 'lib/Style'
 import styles from './FieldReference.css'
@@ -57,13 +57,11 @@ export default class FieldReferenceList extends Component {
     if (!referencedCollection) return null
 
     const optionsBlock = schema.publish && schema.publish.options
-    const displayableFields = filterVisibleFields({
+    const displayableFields = getVisibleFields({
       fields: referencedCollection.fields,
-      view: 'list'
+      viewType: 'list'
     })
-
     const firstStringField = this.findFirstStringField(displayableFields)
-
     const values = value && !(value instanceof Array) ? [value] : value
 
     if (values) {

--- a/frontend/components/FieldString/FieldStringEdit.jsx
+++ b/frontend/components/FieldString/FieldStringEdit.jsx
@@ -148,7 +148,7 @@ export default class FieldStringEdit extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const {forceValidation, meta, value} = this.props
+    const {forceValidation, value} = this.props
 
     if (!prevProps.forceValidation && forceValidation) {
       this.validate(value)

--- a/frontend/components/FieldString/FieldStringEdit.jsx
+++ b/frontend/components/FieldString/FieldStringEdit.jsx
@@ -173,7 +173,7 @@ export default class FieldStringEdit extends Component {
       Object.keys(validation).forEach(validationRule => {
         switch (validationRule) {
           case 'minLength':
-            if (valueLength < validation.minLength) {
+            if (valueLength > 0 && valueLength < validation.minLength) {
               hasValidationErrors = validationMessage || true
             }
 
@@ -239,10 +239,13 @@ export default class FieldStringEdit extends Component {
   handleOnChange(value) {
     const {name, onChange, schema} = this.props
 
-    this.validate(value)
+    // We prefer sending a `null` over an empty string.
+    let sanitisedValue = value === '' ? null : value
+
+    this.validate(sanitisedValue)
 
     if (typeof onChange === 'function') {
-      onChange.call(this, name, value)
+      onChange.call(this, name, sanitisedValue)
     }
   }
 

--- a/frontend/components/FileUpload/FileUpload.jsx
+++ b/frontend/components/FileUpload/FileUpload.jsx
@@ -39,6 +39,7 @@ export default class FileUpload extends Component {
   }
 
   static defaultProps = {
+    accept: ['*/*'],
     multiple: false
   }
 

--- a/frontend/containers/DocumentEdit/DocumentEdit.jsx
+++ b/frontend/containers/DocumentEdit/DocumentEdit.jsx
@@ -13,7 +13,6 @@ import * as routerActions from 'actions/routerActions'
 import * as fieldComponents from 'lib/field-components'
 
 import APIBridge from 'lib/api-bridge-client'
-import {visibleFieldList, filterVisibleFields} from 'lib/fields'
 import {buildUrl} from 'lib/router'
 import {connectHelper} from 'lib/util'
 import {Format} from 'lib/util/string'

--- a/frontend/containers/DocumentList/DocumentList.jsx
+++ b/frontend/containers/DocumentList/DocumentList.jsx
@@ -15,7 +15,6 @@ import * as fieldComponents from 'lib/field-components'
 
 import APIBridge from 'lib/api-bridge-client'
 import {createRoute} from 'lib/router'
-import {filterVisibleFields, getFieldType} from 'lib/fields'
 import {connectHelper} from 'lib/util'
 
 import ErrorMessage from 'components/ErrorMessage/ErrorMessage'
@@ -51,6 +50,11 @@ class DocumentList extends Component {
      * When on a reference field, contains the ID of the parent document.
      */
     documentId: proptypes.string,
+
+    /**
+     * The list of fields to retrieve.
+     */
+    fields: proptypes.array,
 
     /**
      * The hash map of active filters.
@@ -247,6 +251,7 @@ class DocumentList extends Component {
       api,
       collection,
       collectionParent,
+      fields,
       filters = {},
       order,
       page,
@@ -271,6 +276,7 @@ class DocumentList extends Component {
       api,
       collection,
       count,
+      fields,
       filters,
       page,
       parentCollection: collectionParent,
@@ -334,7 +340,7 @@ class DocumentList extends Component {
       onPageTitle(
         (collection.settings && collection.settings.description) || collection.name
       )      
-    }    
+    }
 
     const items = documents.list.results
 

--- a/frontend/containers/MediaListController/MediaListController.jsx
+++ b/frontend/containers/MediaListController/MediaListController.jsx
@@ -36,7 +36,7 @@ class DocumentListController extends Component {
   handleUpload(files) {
     const {actions, api} = this.props
 
-    actions.uploadMedia({
+    actions.saveMediaDocuments({
       api,
       files: Array.from(files)
     })

--- a/frontend/reducers/document.js
+++ b/frontend/reducers/document.js
@@ -142,6 +142,14 @@ export default function document (state = initialState, action = {}) {
     case Types.SET_REMOTE_DOCUMENT_STATUS:
       switch (action.status) {
 
+        // Document is idle.
+        case Constants.STATUS_IDLE:
+          return {
+            ...state,
+            isLoading: false,
+            isSaving: false
+          }
+
         // Document is fetching.
         case Constants.STATUS_LOADING:
           return {

--- a/frontend/views/DocumentEditView/DocumentEditView.jsx
+++ b/frontend/views/DocumentEditView/DocumentEditView.jsx
@@ -3,7 +3,7 @@
 import {h, Component} from 'preact'
 import {bindActionCreators} from 'redux'
 import {connectHelper, setPageTitle} from 'lib/util'
-import {filterVisibleFields} from 'lib/fields'
+import {getVisibleFields} from 'lib/fields'
 import {Format} from 'lib/util/string'
 import {route} from '@dadi/preact-router'
 import {URLParams} from 'lib/util/urlParams'
@@ -139,9 +139,9 @@ class DocumentEditView extends Component {
     const {currentApi, currentCollection} = state.api
 
     if (currentCollection) {
-      let collectionFields = filterVisibleFields({
+      let collectionFields = getVisibleFields({
         fields: currentCollection.fields,
-        view: 'edit'
+        viewType: 'edit'
       })
 
       this.sections = this.groupFieldsIntoSections(collectionFields)

--- a/frontend/views/DocumentListView/DocumentListView.jsx
+++ b/frontend/views/DocumentListView/DocumentListView.jsx
@@ -3,10 +3,12 @@
 import {Component, h} from 'preact'
 import {bindActionCreators} from 'redux'
 import {connectHelper, setPageTitle} from 'lib/util'
+import {getVisibleFields} from 'lib/fields'
 import {route} from '@dadi/preact-router'
 import {URLParams} from 'lib/util/urlParams'
 
 import * as appActions from 'actions/appActions'
+import * as Constants from 'lib/constants'
 import * as documentsActions from 'actions/documentsActions'
 
 import Button from 'components/Button/Button'
@@ -162,6 +164,12 @@ class DocumentListView extends Component {
     const {
       search = {}
     } = state.router
+    const visibleFields = Object.keys(
+      getVisibleFields({
+        fields: currentCollection && currentCollection.fields,
+        viewType: 'list'
+      })
+    ).concat(Constants.DEFAULT_FIELDS)
 
     return (
       <Page>
@@ -184,11 +192,15 @@ class DocumentListView extends Component {
             collection={currentCollection}
             collectionParent={currentParentCollection}
             documentId={documentId}
+            fields={visibleFields}
             filters={search.filter}
             onBuildBaseUrl={onBuildBaseUrl.bind(this)}
             onPageTitle={setPageTitle}
             onRenderDocuments={props => (
-              <DocumentTableList {...props} />
+              <DocumentTableList
+                {...props}
+                fields={visibleFields}
+              />
             )}
             onRenderEmptyDocumentList={this.handleEmptyDocumentList.bind(this)}
             order={order}

--- a/frontend/views/MediaEditView/MediaEditView.jsx
+++ b/frontend/views/MediaEditView/MediaEditView.jsx
@@ -3,7 +3,6 @@
 import {h, Component} from 'preact'
 import {bindActionCreators} from 'redux'
 import {connectHelper, setPageTitle} from 'lib/util'
-import {filterVisibleFields} from 'lib/fields'
 import {Format} from 'lib/util/string'
 import {route} from '@dadi/preact-router'
 import {URLParams} from 'lib/util/urlParams'

--- a/frontend/views/ReferenceSelectView/ReferenceSelectView.jsx
+++ b/frontend/views/ReferenceSelectView/ReferenceSelectView.jsx
@@ -4,10 +4,11 @@ import {Component, h} from 'preact'
 import {bindActionCreators} from 'redux'
 import {connectHelper, setPageTitle} from 'lib/util'
 import {Format} from 'lib/util/string'
-import {filterVisibleFields, getFieldType} from 'lib/fields'
+import {getFieldType, getVisibleFields} from 'lib/fields'
 import {route} from '@dadi/preact-router'
 import {URLParams} from 'lib/util/urlParams'
 
+import * as Constants from 'lib/constants'
 import * as documentActions from 'actions/documentActions'
 import * as documentsActions from 'actions/documentsActions'
 import * as fieldComponents from 'lib/field-components'
@@ -118,7 +119,7 @@ class ReferenceSelectView extends Component {
     )    
   }
 
-  handleRenderDocuments(reference, documentProps) {
+  handleRenderDocuments(reference, fields, documentProps) {
     let selectLimit = reference.limit || Infinity
 
     if (reference.collection.IS_MEDIA_BUCKET) {
@@ -139,7 +140,10 @@ class ReferenceSelectView extends Component {
     }
 
     return (
-      <DocumentTableList {...documentProps} />
+      <DocumentTableList
+        {...documentProps}
+        fields={fields}
+      />
     )
   }
 
@@ -214,6 +218,12 @@ class ReferenceSelectView extends Component {
       `Add selected ${selectedDocuments.length > 1 ? 'documents' : 'document'}`
 
     let filters = Object.assign({}, reference.filter, search.filter)
+    let fields = Object.keys(
+      getVisibleFields({
+        fields: reference.collection && reference.collection.fields,
+        viewType: 'list'
+      })
+    ).concat(Constants.DEFAULT_FIELDS)
 
     return (
       <Page>
@@ -239,10 +249,15 @@ class ReferenceSelectView extends Component {
             collection={reference.collection}
             collectionParent={currentCollection}
             documentId={documentId}
+            fields={fields}
             filters={filters}
             onBuildBaseUrl={onBuildBaseUrl.bind(this)}
             onPageTitle={setPageTitle}
-            onRenderDocuments={this.handleRenderDocuments.bind(this, reference)}
+            onRenderDocuments={this.handleRenderDocuments.bind(
+              this,
+              reference,
+              fields
+            )}
             onRenderEmptyDocumentList={this.handleEmptyDocumentList.bind(this)}
             order={order}
             page={page}


### PR DESCRIPTION
## Part 1

When a field of type `Media` has a `validation.mimeTypes` array defined, any filed dropped into the field that doesn't respect the validation rule triggers an error, displayed in a similar fashion to the errors generated by other field types, as shown by the screenshot below.

<img width="1067" alt="screenshot 2018-11-28 at 12 48 43" src="https://user-images.githubusercontent.com/4162329/49152987-4bb35080-f30c-11e8-8ae0-0f06ec5c7f99.png">

Closes #543.

## Part 2

Prevent the `minLength` validation rule from blocking a save when the field is empty.

Closes #419.

## Part 3

Refactor the way the document edit and document list views compute the list of fields that should be displayed, so that the `publish.display` properties are taken into account if and only if at least one of the fields in the collection has them. If not, all fields are displayed by default.

## Part 4

Refactor the action for saving documents in order to process not only fields of type `Reference` but also `Media`.

## Part 5

Make `Reference` and `Media` fields flag validation errors and display schema comments.

## Part 6

Fix an issue where it was impossible to save a document after a remote validation error occurred.

Closes #419.