### PR TITLE
Improve config validation

### DIFF
--- a/app/config-schema.js
+++ b/app/config-schema.js
@@ -2,7 +2,7 @@ module.exports = {
   apis: {
     requireAuthentication: false,
     doc: 'Connected APIs',
-    format: Array,
+    format: 'apis-block',
     default: [],
     publishId: {
       type: String,
@@ -94,7 +94,6 @@ module.exports = {
     }
   },
   server: {
-    requireAuthentication: false,
     host: {
       doc: 'The IP address or interface to bind to',
       format: 'ipaddress',
@@ -147,6 +146,7 @@ module.exports = {
       env: 'SSL_INTERMEDIATE_CERTIFICATE_PATHS'
     },
     healthcheck: {
+      requireAuthentication: false,
       enabled: {
         doc: 'Healthcheck is enabled',
         format: Boolean,

--- a/app/config.js
+++ b/app/config.js
@@ -78,6 +78,29 @@ const initialiseConfig = () => {
   return config
 }
 
+convict.addFormat({
+  name: 'apis-block',
+  validate: value => {
+    if (!Array.isArray(value)) {
+      throw new Error('must be an array')
+    }
+
+    if (value.length > 1) {
+      throw new Error('only one API is currently supported')
+    }
+
+    value.forEach(api => {
+      if (typeof api.host !== 'string' || typeof api.port !== 'number') {
+        throw new Error('must contain elements with `host` and `port` properties')
+      }
+
+      if (api.credentials !== undefined) {
+        throw new Error('contains a legacy `credentials` block, exposing critical information to the public')
+      }
+    })
+  }
+})
+
 let config = initialiseConfig()
 
 module.exports = config

--- a/frontend/components/FieldNumber/FieldNumberEdit.jsx
+++ b/frontend/components/FieldNumber/FieldNumberEdit.jsx
@@ -101,7 +101,6 @@ export default class FieldNumberEdit extends Component {
 
   static defaultProps = {
     error: false,
-    forceValidation: false,
     value: null
   }
 
@@ -111,19 +110,17 @@ export default class FieldNumberEdit extends Component {
     this.state.hasFocus = false
   }
 
-  componentDidMount() {
-    const {forceValidation, value} = this.props
-
-    if (forceValidation) {
-      this.validate(value)
-    }
+  handleFocusChange(hasFocus) {
+    this.setState({
+      hasFocus
+    })
   }
 
-  componentDidUpdate(prevProps, prevState) {
-    const {forceValidation, value} = this.props
+  handleOnChange(event) {
+    const {name, onChange, schema} = this.props
 
-    if (!prevProps.forceValidation && forceValidation) {
-      this.validate(value)
+    if (typeof onChange === 'function') {
+      onChange.call(this, name, parseFloat(event.target.value))
     }
   }
 
@@ -160,38 +157,5 @@ export default class FieldNumberEdit extends Component {
         />
       </Label>
     )
-  }
-
-  getValueOfInput(input) {
-    return parseFloat(input.value)
-  }
-
-  handleFocusChange(hasFocus) {
-    this.setState({
-      hasFocus
-    })
-  }
-
-  handleOnChange(event) {
-    const {name, onChange, schema} = this.props
-    const value = this.getValueOfInput(event.target)
-
-    this.validate(value)
-
-    if (typeof onChange === 'function') {
-      onChange.call(this, name, parseFloat(event.target.value))
-    }
-  }
-
-  validate(value) {
-    const {name, onError, required, schema} = this.props
-
-    const hasValidationErrors = required && (isNaN(value)
-      || typeof value !== 'number') 
-    //{To-Do}: add findValidationErrorsInValue method for further validation checks 
-
-    if (typeof onError === 'function') {
-        onError.call(this, name, hasValidationErrors, value)
-    }
   }
 }

--- a/frontend/components/FieldReference/FieldReferenceEdit.jsx
+++ b/frontend/components/FieldReference/FieldReferenceEdit.jsx
@@ -259,7 +259,7 @@ export default class FieldReferenceEdit extends Component {
     const hasValidationErrors = required && !value
 
     if (typeof onError === 'function') {
-      onError.call(this, name, hasValidationErrors, value)
+      //onError.call(this, name, hasValidationErrors, value)
     }    
   }
 }


### PR DESCRIPTION
This PR removes most of the `server` config block from the front-end and adds some validation rules to the `apis` block, stopping the application if the legacy `credentials` block is found.