### PR TITLE
Improve config validation

### DIFF
--- a/app/config-schema.js
+++ b/app/config-schema.js
@@ -2,7 +2,7 @@ module.exports = {
   apis: {
     requireAuthentication: false,
     doc: 'Connected APIs',
-    format: Array,
+    format: 'apis-block',
     default: [],
     publishId: {
       type: String,
@@ -94,7 +94,6 @@ module.exports = {
     }
   },
   server: {
-    requireAuthentication: false,
     host: {
       doc: 'The IP address or interface to bind to',
       format: 'ipaddress',
@@ -147,6 +146,7 @@ module.exports = {
       env: 'SSL_INTERMEDIATE_CERTIFICATE_PATHS'
     },
     healthcheck: {
+      requireAuthentication: false,
       enabled: {
         doc: 'Healthcheck is enabled',
         format: Boolean,

--- a/app/config.js
+++ b/app/config.js
@@ -78,6 +78,29 @@ const initialiseConfig = () => {
   return config
 }
 
+convict.addFormat({
+  name: 'apis-block',
+  validate: value => {
+    if (!Array.isArray(value)) {
+      throw new Error('must be an array')
+    }
+
+    if (value.length > 1) {
+      throw new Error('only one API is currently supported')
+    }
+
+    value.forEach(api => {
+      if (typeof api.host !== 'string' || typeof api.port !== 'number') {
+        throw new Error('must contain elements with `host` and `port` properties')
+      }
+
+      if (api.credentials !== undefined) {
+        throw new Error('contains a legacy `credentials` block, exposing critical information to the public')
+      }
+    })
+  }
+})
+
 let config = initialiseConfig()
 
 module.exports = config


### PR DESCRIPTION
This PR removes most of the `server` config block from the front-end and adds some validation rules to the `apis` block, stopping the application if the legacy `credentials` block is found.