### PR TITLE
Various improvements for mobile

### DIFF
--- a/frontend/components/BulkActionSelector/BulkActionSelector.css
+++ b/frontend/components/BulkActionSelector/BulkActionSelector.css
@@ -1,5 +1,6 @@
 .container {
   display: flex;
+  margin-top: 10px;
   width: 100%;
 }
 
@@ -14,10 +15,15 @@
 
 @media (--breakpoint-medium) {
   .container {
+    margin-top: 0;
     width: auto;
   }
 
   .container-empty {
     display: block;
+  }
+
+  .dropdown {
+    min-width: 130px;
   }
 }

--- a/frontend/components/BulkActionSelector/BulkActionSelector.css
+++ b/frontend/components/BulkActionSelector/BulkActionSelector.css
@@ -1,0 +1,23 @@
+.container {
+  display: flex;
+  width: 100%;
+}
+
+.container-empty {
+  display: none;
+}
+
+.dropdown {
+  flex-grow: 1;
+  margin-right: 10px;
+}
+
+@media (--breakpoint-medium) {
+  .container {
+    width: auto;
+  }
+
+  .container-empty {
+    display: block;
+  }
+}

--- a/frontend/components/BulkActionSelector/BulkActionSelector.jsx
+++ b/frontend/components/BulkActionSelector/BulkActionSelector.jsx
@@ -72,6 +72,11 @@ export default class BulkActionSelector extends Component {
     const containerStyle = new Style(styles, 'container')
       .addIf('container-empty', selection.length === 0)
       .addResolved(className)
+    let placeholder = 'With selected'
+
+    if (selection.length > 0) {
+      placeholder += ` (${selection.length})`
+    }
 
     return (
       <div class={containerStyle.getClasses()}>
@@ -79,7 +84,7 @@ export default class BulkActionSelector extends Component {
           className={styles.dropdown}
           onChange={this.onChange.bind(this)}
           options={actions}
-          placeholderLabel="With selected..."
+          placeholderLabel={placeholder}
           placeholderValue={ACTION_PLACEHOLDER}
           textSize="small"
           value={selected}

--- a/frontend/components/BulkActionSelector/BulkActionSelector.jsx
+++ b/frontend/components/BulkActionSelector/BulkActionSelector.jsx
@@ -1,0 +1,99 @@
+'use strict'
+
+import {h, Component} from 'preact'
+import proptypes from 'proptypes'
+
+import Style from 'lib/Style'
+import styles from './BulkActionSelector.css'
+
+import ButtonWithPrompt from 'components/ButtonWithPrompt/ButtonWithPrompt'
+import DropdownNative from 'components/DropdownNative/DropdownNative'
+
+const ACTION_PLACEHOLDER = 'ACTION_PLACEHOLDER'
+
+/**
+ * A dropdown + button to apply actions to a series of elements.
+ */
+export default class BulkActionSelector extends Component {
+  static propTypes = {
+    /**
+     * List of possible actions. Must be an object mapping action IDs
+     * to action labels.
+     */
+    actions: proptypes.object,
+
+    /**
+     * Classes to append to the element.
+     */
+    className: proptypes.string,
+
+    /**
+     * Callback to be executed when a value is selected.
+     */
+    onChange: proptypes.func,
+
+    /**
+     * Array of selected elements.
+     */
+    selection: proptypes.array
+  }
+
+  constructor(props) {
+    super(props)
+
+    this.state.selected = ACTION_PLACEHOLDER
+  }
+
+  onApply() {
+    const {onChange} = this.props
+    const {selected} = this.state
+
+    if (!selected || selected === ACTION_PLACEHOLDER) return
+
+    if (typeof onChange === 'function') {
+      onChange.call(this, selected)
+    }
+  }
+
+  onChange(value) {
+    this.setState({
+      selected: value
+    })
+  }
+
+  render() {
+    const {
+      actions,
+      className,
+      onChange,
+      selection = []
+    } = this.props
+    const {selected} = this.state
+    const containerStyle = new Style(styles, 'container')
+      .addIf('container-empty', selection.length === 0)
+      .addResolved(className)
+
+    return (
+      <div class={containerStyle.getClasses()}>
+        <DropdownNative
+          className={styles.dropdown}
+          onChange={this.onChange.bind(this)}
+          options={actions}
+          placeholderLabel="With selected..."
+          placeholderValue={ACTION_PLACEHOLDER}
+          textSize="small"
+          value={selected}
+        />
+
+        <ButtonWithPrompt
+          accent="data"
+          disabled={(selected === ACTION_PLACEHOLDER) || !selection.length}
+          onClick={this.onApply.bind(this)}
+          promptCallToAction={`Yes, delete ${selection.length > 1 ? 'them' : 'it'}.`}
+          promptMessage={`Are you sure you want to delete the selected ${selection.length > 1 ? 'documents' : 'document'}?`}
+          size="small"
+        >Apply</ButtonWithPrompt>
+      </div>
+    )
+  }
+}

--- a/frontend/components/Button/Button.css
+++ b/frontend/components/Button/Button.css
@@ -144,7 +144,8 @@
 }
 
 /* Disabled */
-.button[disabled]:not(.button-inherit) {
+.button[disabled]:not(.button-inherit),
+.button-disabled:not(.button-inherit) {
   background-color: var(--theme-colour-background-shade-2, #AAAAAA) !important;
   color: var(--theme-colour-secondary, #FFFFFF) !important;
   cursor: not-allowed !important;

--- a/frontend/components/Button/Button.jsx
+++ b/frontend/components/Button/Button.jsx
@@ -110,6 +110,7 @@ export default class Button extends Component {
     const buttonStyle = new Style(styles, 'button')
 
     buttonStyle.add(`button-${accent}`)
+      .addIf('button-disabled', disabled)
       .addIf('button-loading', isLoading)
       .addIf(`button-in-group-${inGroup}`, inGroup)
       .addIf('button-mock', type === 'mock')

--- a/frontend/components/DocumentFilters/DocumentFilters.css
+++ b/frontend/components/DocumentFilters/DocumentFilters.css
@@ -3,7 +3,7 @@
   position: relative;
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
 }
 
 @media (--breakpoint-small) {
@@ -23,7 +23,6 @@
   .filters {
     order: 3;
     width: 100%;
-    margin-top: 5px;
   }
 }
 

--- a/frontend/components/DocumentListController/DocumentListController.css
+++ b/frontend/components/DocumentListController/DocumentListController.css
@@ -1,16 +1,17 @@
 .wrapper {
   border-top: 1px solid #282f39;
   background-image: linear-gradient(-180deg, #0b131f 10%, #17273f 100%); 
+  display: flex;
   padding: 15px 20px;
 }
 
 .actions {
-  margin-bottom: 10px;
+  margin-left: 10px;
 }
 
 @media (--breakpoint-medium) {
   .actions {
-    margin-bottom: 0;
+    margin-left: 0;
     padding-left: 10px;
   }
 
@@ -20,6 +21,19 @@
 
   .filters {
     flex-grow: 1;
-    order: -1;
+  }
+}
+
+.new-button-large {
+  display: none;
+}
+
+@media (--breakpoint-medium) {
+  .new-button-large {
+    display: block;
+  }
+
+  .new-button-small {
+    display: none;
   }
 }

--- a/frontend/components/DocumentListController/DocumentListController.css
+++ b/frontend/components/DocumentListController/DocumentListController.css
@@ -3,6 +3,7 @@
   background-image: linear-gradient(-180deg, #0b131f 10%, #17273f 100%); 
   display: flex;
   padding: 15px 20px;
+  align-items: center
 }
 
 .actions {

--- a/frontend/components/DocumentListController/DocumentListController.jsx
+++ b/frontend/components/DocumentListController/DocumentListController.jsx
@@ -63,16 +63,6 @@ export default class DocumentListController extends Component {
 
     return (
       <div class={styles.wrapper}>
-        <div class={styles.actions}>
-          {createNewHref &&
-            <Button
-              accent="save"
-              href={createNewHref}
-              type="fill"
-            >Create new</Button>
-          }
-        </div>
-
         <div class={styles.filters}>
           {enableFilters &&
             <DocumentFilters
@@ -80,6 +70,28 @@ export default class DocumentListController extends Component {
               filters={search.filter}
               onUpdateFilters={this.handleFiltersUpdate.bind(this)}
             />
+          }
+        </div>
+
+        <div class={styles.actions}>
+          {createNewHref &&
+            <div class={styles['new-button-large']}>
+              <Button
+                accent="save"
+                href={createNewHref}
+                type="fill"
+              >Create new</Button>
+            </div>
+          }
+
+          {createNewHref &&
+            <div class={styles['new-button-small']}>
+              <Button
+                accent="save"
+                href={createNewHref}
+                type="fill"
+              >New</Button>
+            </div>
           }
         </div>
       </div>

--- a/frontend/components/DocumentListToolbar/DocumentListToolbar.css
+++ b/frontend/components/DocumentListToolbar/DocumentListToolbar.css
@@ -1,5 +1,4 @@
 .information {
-  display: none;
   align-items: center;
 }
 
@@ -10,7 +9,14 @@
 }
 
 .count-label {
+  display: none;
   margin-left: 0;
+}
+
+@media (--breakpoint-large) {
+  .count-label {
+    display: inline;
+  }
 }
 
 .section {
@@ -19,7 +25,25 @@
   text-align: center;
 }
 
+.section-pagination {
+  justify-content: space-between;
+}
+
 .page-input {
   width: 6em;
   text-align: center;
+}
+
+.page-input-simple {
+  display: none;
+}
+
+@media (--breakpoint-large) {
+  .page-input-simple {
+    display: block;
+  }
+
+  .page-input-extended {
+    display: none;
+  }
 }

--- a/frontend/components/DocumentListToolbar/DocumentListToolbar.css
+++ b/frontend/components/DocumentListToolbar/DocumentListToolbar.css
@@ -9,12 +9,19 @@
 }
 
 .count-label {
+  width: 100%;
+}
+
+.count-label-prefix {
   display: none;
-  margin-left: 0;
 }
 
 @media (--breakpoint-large) {
   .count-label {
+    width: auto;
+  }
+
+  .count-label-prefix {
     display: inline;
   }
 }
@@ -27,6 +34,13 @@
 
 .section-pagination {
   justify-content: space-between;
+  margin-top: 10px;
+}
+
+@media (--breakpoint-large) {
+  .section-pagination {
+    margin-top: 0;
+  }
 }
 
 .page-input {

--- a/frontend/components/DocumentListToolbar/DocumentListToolbar.jsx
+++ b/frontend/components/DocumentListToolbar/DocumentListToolbar.jsx
@@ -10,6 +10,7 @@ import styles from './DocumentListToolbar.css'
 import * as Constants from 'lib/constants'
 
 import Checkbox from 'components/Checkbox/Checkbox'
+import DropdownNative from 'components/DropdownNative/DropdownNative'
 import Paginator from 'components/Paginator/Paginator'
 import Toolbar from 'components/Toolbar/Toolbar'
 import ToolbarTextInput from 'components/Toolbar/ToolbarTextInput'
@@ -35,18 +36,17 @@ export default class DocumentListToolbar extends Component {
     onBuildPageUrl: proptypes.func
   }
 
-  handleGoToPage(event) {
+  goToPage(value) {
     const {
       documentsMetadata,
       onBuildPageUrl
     } = this.props
-    const inputValue = event.target.value
-    const parsedValue = parseInt(inputValue)
+    const parsedValue = parseInt(value)
 
     if (!documentsMetadata) return null
 
     // If the input is not a valid positive integer number, we return.
-    if ((parsedValue.toString() !== inputValue) || (parsedValue <= 0)) return
+    if ((parsedValue.toString() !== value) || (parsedValue <= 0)) return
 
     // If the number inserted is outside the range of the pages available,
     // we return.
@@ -65,6 +65,16 @@ export default class DocumentListToolbar extends Component {
     } = this.props
 
     if (!metadata) return null
+
+    const pagesObject = Array.apply(null, {
+      length: metadata.totalPages
+    }).reduce((result, content, index) => {
+      const page = index + 1
+
+      result[page] = `Page ${page}`
+      
+      return result
+    }, {})
 
     return (
       <Toolbar>      
@@ -90,7 +100,7 @@ export default class DocumentListToolbar extends Component {
               <div>
                 <span class={`${styles['page-input']} ${styles['page-input-simple']}`}>
                   <ToolbarTextInput
-                    onChange={this.handleGoToPage.bind(this)}
+                    onChange={event => goToPage.bind(event.target.value)}
                     size="small"
                     placeholder="Go to page"
                     type="number"
@@ -98,11 +108,10 @@ export default class DocumentListToolbar extends Component {
                 </span>
 
                 <span class={`${styles['page-input']} ${styles['page-input-extended']}`}>
-                  <ToolbarTextInput
-                    onChange={this.handleGoToPage.bind(this)}
-                    size="small"
-                    placeholder={`Page ${metadata.page}`}
-                    type="number"
+                  <DropdownNative
+                    onChange={this.goToPage.bind(this)}
+                    options={pagesObject}
+                    value={metadata.page}
                   />
                 </span>
               </div>

--- a/frontend/components/DocumentListToolbar/DocumentListToolbar.jsx
+++ b/frontend/components/DocumentListToolbar/DocumentListToolbar.jsx
@@ -77,7 +77,7 @@ export default class DocumentListToolbar extends Component {
             </span>
           </div>
         )}
-        <div class={styles.section}>
+        <div class={`${styles.section} ${styles['section-pagination']}`}>
           <Paginator
             currentPage={metadata.page}
             linkCallback={page => onBuildPageUrl(page)}
@@ -87,13 +87,25 @@ export default class DocumentListToolbar extends Component {
 
           <div class={styles.information}>
             {metadata.totalCount > metadata.limit && (
-              <span class={styles['page-input']}>
-                <ToolbarTextInput
-                  onChange={this.handleGoToPage.bind(this)}
-                  size="small"
-                  placeholder="Go to page"
-                />
-              </span>
+              <div>
+                <span class={`${styles['page-input']} ${styles['page-input-simple']}`}>
+                  <ToolbarTextInput
+                    onChange={this.handleGoToPage.bind(this)}
+                    size="small"
+                    placeholder="Go to page"
+                    type="number"
+                  />
+                </span>
+
+                <span class={`${styles['page-input']} ${styles['page-input-extended']}`}>
+                  <ToolbarTextInput
+                    onChange={this.handleGoToPage.bind(this)}
+                    size="small"
+                    placeholder={`Page ${metadata.page}`}
+                    type="number"
+                  />
+                </span>
+              </div>
             )} 
           </div>
         </div>

--- a/frontend/components/DocumentListToolbar/DocumentListToolbar.jsx
+++ b/frontend/components/DocumentListToolbar/DocumentListToolbar.jsx
@@ -87,23 +87,23 @@ export default class DocumentListToolbar extends Component {
             </span>
           </div>
         )}
-        <div class={`${styles.section} ${styles['section-pagination']}`}>
-          <Paginator
-            currentPage={metadata.page}
-            linkCallback={page => onBuildPageUrl(page)}
-            maxPages={8}
-            totalPages={metadata.totalPages}
-          />
 
-          <div class={styles.information}>
-            {metadata.totalCount > metadata.limit && (
+        {metadata.totalCount > metadata.limit && (
+          <div class={`${styles.section} ${styles['section-pagination']}`}>
+            <Paginator
+              currentPage={metadata.page}
+              linkCallback={page => onBuildPageUrl(page)}
+              maxPages={8}
+              totalPages={metadata.totalPages}
+            />
+
+            <div class={styles.information}>
               <div>
                 <span class={`${styles['page-input']} ${styles['page-input-simple']}`}>
                   <ToolbarTextInput
                     onChange={event => goToPage.bind(event.target.value)}
                     size="small"
                     placeholder="Go to page"
-                    type="number"
                   />
                 </span>
 
@@ -115,9 +115,9 @@ export default class DocumentListToolbar extends Component {
                   />
                 </span>
               </div>
-            )} 
+            </div>
           </div>
-        </div>
+        )}
 
         <div class={styles.section}>
           {children}

--- a/frontend/components/Paginator/Paginator.css
+++ b/frontend/components/Paginator/Paginator.css
@@ -4,11 +4,13 @@
   border-radius: 0;
 }
 
-.page:first-child {
+.page:first-child,
+.page-first {
   border-radius: 4px 0 0 4px;
 }
 
-.page:last-child {
+.page:last-child,
+.page-last {
   border-radius: 0 4px 4px 0;
   margin-right: 10px;
 }
@@ -18,6 +20,10 @@
 }
 
 @media (--breakpoint-medium) {
+  .page-disabled {
+    visibility: hidden;
+  }
+
   .page-primary {
     display: inline-block;
   }

--- a/frontend/components/Paginator/Paginator.css
+++ b/frontend/components/Paginator/Paginator.css
@@ -13,6 +13,16 @@
   margin-right: 10px;
 }
 
-.page-secondary {
-  color: var(--theme-colour-background-shade-2, #AAAAAA);
+.page-primary {
+  display: none;
 }
+
+@media (--breakpoint-medium) {
+  .page-primary {
+    display: inline-block;
+  }
+
+  .page-secondary {
+    color: var(--theme-colour-background-shade-2, #AAAAAA);
+  }
+}  

--- a/frontend/components/Paginator/Paginator.jsx
+++ b/frontend/components/Paginator/Paginator.jsx
@@ -46,10 +46,12 @@ export default class Paginator extends Component {
     prevNext: true
   }
 
-  renderPageNumber(pageNumber) {
+  renderPageNumber(pageNumber, firstPage, lastPage) {
     const {currentPage, linkCallback} = this.props
     const href = linkCallback.call(this, pageNumber)
     const pageStyle = new Style(styles, 'page', 'page-primary')
+      .addIf('page-first', pageNumber === currentPage && pageNumber === firstPage)
+      .addIf('page-last', pageNumber === currentPage && pageNumber === lastPage)
 
     if (pageNumber === currentPage) {
       return (
@@ -121,37 +123,46 @@ export default class Paginator extends Component {
     let lastPage = (currentPage + nextPages)
 
     for (let i = firstPage; i <= lastPage; i++) {
-      items.push(this.renderPageNumber(i))
+      items.push(this.renderPageNumber(i, firstPage, lastPage, currentPage))
     }
 
     const nextUrl = linkCallback(currentPage + 1)
     const prevUrl = linkCallback(currentPage - 1)
-    const prevNextStyle = new Style(styles, 'page', 'page-secondary')
+    const isFirstPage = currentPage <= 1
+    const isLastPage = currentPage >= totalPages
+    const nextStyle = new Style(styles, 'page', 'page-secondary')
+      .addIf('page-disabled', isLastPage)
+    const prevStyle = new Style(styles, 'page', 'page-secondary')
+      .addIf('page-disabled', isFirstPage)
 
     // If there's less than two pages to show, don't show page numbers.
     if (items.length < 2) return null
 
     return (
       <div>
-        {prevNext && (currentPage > 1) &&
+        {prevNext &&
           <Button
-            className={prevNextStyle.getClasses()}
+            className={prevStyle.getClasses()}
+            disabled={isFirstPage}
             href={createRoute({
               path: prevUrl,
               update: true
             })}
-          >Prev</Button>
+            type={isFirstPage && 'mock'}
+          >Prev</Button> 
         }
 
         {items}
 
-        {prevNext && (currentPage < totalPages) &&
+        {prevNext &&
           <Button
-            className={prevNextStyle.getClasses()}
+            className={nextStyle.getClasses()}
+            disabled={isLastPage}
             href={createRoute({
               path: nextUrl,
               update: true
             })}
+            type={isLastPage && 'mock'}
           >Next</Button>
         }
       </div>

--- a/frontend/components/Paginator/Paginator.jsx
+++ b/frontend/components/Paginator/Paginator.jsx
@@ -49,13 +49,13 @@ export default class Paginator extends Component {
   renderPageNumber(pageNumber) {
     const {currentPage, linkCallback} = this.props
     const href = linkCallback.call(this, pageNumber)
-    const activePageStyle = new Style(styles, 'page', 'page-active')
+    const pageStyle = new Style(styles, 'page', 'page-primary')
 
     if (pageNumber === currentPage) {
       return (
         <Button
           accent="data"
-          className={styles.page}
+          className={pageStyle.getClasses()}
           type="mock"
         >{pageNumber}</Button>
       )
@@ -67,7 +67,7 @@ export default class Paginator extends Component {
           path: href,
           update: true
         })}
-        className={styles.page}
+        className={pageStyle.getClasses()}
       >{pageNumber}</Button>
     )    
   }

--- a/frontend/components/Toolbar/Toolbar.css
+++ b/frontend/components/Toolbar/Toolbar.css
@@ -8,6 +8,9 @@
   font-family: var(--theme-font-family, sans-serif);
   color: var(--theme-colour-primary, #000000);
   z-index: 1000;
+  position: fixed;
+  bottom: 0;
+  left: 0;
 }
 
 @media (--breakpoint-medium) {
@@ -15,9 +18,6 @@
     display: flex;
     justify-content: space-between;
     align-items: stretch;
-    position: fixed;
-    bottom: 0;
-    left: 0;
     border-top: 1px solid #e4e4e4;
   }
 }

--- a/frontend/components/Toolbar/Toolbar.css
+++ b/frontend/components/Toolbar/Toolbar.css
@@ -12,10 +12,6 @@
   left: 0;
 }
 
-.container > * + * {
-  margin-top: 10px;
-}
-
 @media (--breakpoint-medium) {
   .container {
     display: flex;
@@ -24,10 +20,6 @@
     border-top: 1px solid #e4e4e4;
     min-height: var(--theme-toolbar-height, 63px);
   }
-
-  .container > * + * {
-    margin-top: 0;
-  }  
 }
 
 .container-padded {

--- a/frontend/components/Toolbar/Toolbar.css
+++ b/frontend/components/Toolbar/Toolbar.css
@@ -1,6 +1,5 @@
 .container {
   width: 100%;
-  min-height: var(--theme-toolbar-height, 63px);
   box-shadow: 0 0 1px rgba(0, 0, 0, 0.08);
   border-bottom: 1px solid #e4e4e4;
   box-shadow: 0 -5px 5px rgba(0,0,0,0.05);
@@ -13,13 +12,22 @@
   left: 0;
 }
 
+.container > * + * {
+  margin-top: 10px;
+}
+
 @media (--breakpoint-medium) {
   .container {
     display: flex;
     justify-content: space-between;
     align-items: stretch;
     border-top: 1px solid #e4e4e4;
+    min-height: var(--theme-toolbar-height, 63px);
   }
+
+  .container > * + * {
+    margin-top: 0;
+  }  
 }
 
 .container-padded {

--- a/frontend/components/Toolbar/ToolbarTextInput.jsx
+++ b/frontend/components/Toolbar/ToolbarTextInput.jsx
@@ -28,11 +28,16 @@ export default class ToolbarTextInput extends Component {
     /**
      * The placeholder to be rendered on the text input.
      */
-    placeholder: proptypes.string
+    placeholder: proptypes.string,
+
+    /**
+     * The type of input.
+     */
+    type: proptypes.string
   }
 
   render() {
-    const {className, onChange, placeholder} = this.props
+    const {className, onChange, placeholder, type} = this.props
     const inputStyle = new Style(styles, 'input')
       .addResolved(className)
 
@@ -41,6 +46,7 @@ export default class ToolbarTextInput extends Component {
         className={inputStyle.getClasses()}
         onChange={onChange}
         placeholder={placeholder}
+        type={type}
       />
     )
   }

--- a/frontend/containers/App/App.jsx
+++ b/frontend/containers/App/App.jsx
@@ -96,6 +96,9 @@ class App extends Component {
         decodeURIComponent(state.router.search.redirect) :
         '/'
 
+      // Scrolling to top (needed on mobile devices).
+      window.scrollTo(0, 0)
+
       return route(redirectUri)
     }
 

--- a/frontend/views/DocumentListView/DocumentListView.jsx
+++ b/frontend/views/DocumentListView/DocumentListView.jsx
@@ -12,12 +12,11 @@ import * as Constants from 'lib/constants'
 import * as documentsActions from 'actions/documentsActions'
 
 import Button from 'components/Button/Button'
-import ButtonWithPrompt from 'components/ButtonWithPrompt/ButtonWithPrompt'
+import BulkActionSelector from 'components/BulkActionSelector/BulkActionSelector'
 import DocumentList from 'containers/DocumentList/DocumentList'
 import DocumentListController from 'components/DocumentListController/DocumentListController'
 import DocumentListToolbar from 'components/DocumentListToolbar/DocumentListToolbar'
 import DocumentTableList from 'components/DocumentTableList/DocumentTableList'
-import DropdownNative from 'components/DropdownNative/DropdownNative'
 import Header from 'containers/Header/Header'
 import HeroMessage from 'components/HeroMessage/HeroMessage'
 import Main from 'components/Main/Main'
@@ -26,17 +25,10 @@ import Style from 'lib/Style'
 import styles from './DocumentListView.css'
 
 const BULK_ACTIONS = {
-  DELETE: 'BULK_ACTIONS_DELETE',
-  PLACEHOLDER: 'BULK_ACTIONS_PLACEHOLDER'
+  DELETE: 'BULK_ACTIONS_DELETE'
 }
 
 class DocumentListView extends Component {
-  constructor(props) {
-    super(props)
-
-    this.state.bulkActionSelected = BULK_ACTIONS.PLACEHOLDER
-  }
-
   componentDidUpdate(prevProps, prevState) {
     const {actions, state} = this.props
     const {isDeleting, list} = state.documents
@@ -71,22 +63,11 @@ class DocumentListView extends Component {
   }
 
   handleBulkActionApply(actionType) {
-    const {state} = this.props    
-    const {bulkActionSelected} = this.state
-    const validBulkActionSelected = bulkActionSelected &&
-      (bulkActionSelected !== BULK_ACTIONS.PLACEHOLDER)
+    const {state} = this.props  
 
-    if (!validBulkActionSelected) return
-
-    if (bulkActionSelected === BULK_ACTIONS.DELETE) {
+    if (actionType === BULK_ACTIONS.DELETE) {
       this.handleDocumentDelete(state.documents.selected)
     }
-  }
-
-  handleBulkActionSelect(value) {
-    this.setState({
-      bulkActionSelected: value
-    })
   }
 
   handleDocumentDelete(ids) {
@@ -215,28 +196,13 @@ class DocumentListView extends Component {
             page
           })}
         >
-          <div>
-            <DropdownNative
-              className={styles['bulk-action-select']}
-              onChange={this.handleBulkActionSelect.bind(this)}
-              options={{
-                [BULK_ACTIONS.DELETE]: 'Delete'
-              }}
-              placeholderLabel="With selected..."
-              placeholderValue={BULK_ACTIONS.PLACEHOLDER}
-              textSize="small"
-              value={bulkActionSelected}
-            />
-
-            <ButtonWithPrompt
-              accent="data"
-              disabled={(bulkActionSelected === BULK_ACTIONS.PLACEHOLDER) || !selectedDocuments.length}
-              onClick={this.handleBulkActionApply.bind(this)}
-              promptCallToAction={`Yes, delete ${selectedDocuments.length > 1 ? 'them' : 'it'}.`}
-              promptMessage={`Are you sure you want to delete the selected ${selectedDocuments.length > 1 ? 'documents' : 'document'}?`}
-              size="small"
-            >Apply</ButtonWithPrompt>
-          </div>        
+          <BulkActionSelector
+            actions={{
+              [BULK_ACTIONS.DELETE]: 'Delete'
+            }}
+            onChange={this.handleBulkActionApply.bind(this)}
+            selection={selectedDocuments}
+          />
         </DocumentListToolbar>
       </Page>
     )

--- a/frontend/views/MediaListView/MediaListView.jsx
+++ b/frontend/views/MediaListView/MediaListView.jsx
@@ -8,11 +8,10 @@ import * as userActions from 'actions/userActions'
 import * as appActions from 'actions/appActions'
 import * as documentsActions from 'actions/documentsActions'
 
-import ButtonWithPrompt from 'components/ButtonWithPrompt/ButtonWithPrompt'
+import BulkActionSelector from 'components/BulkActionSelector/BulkActionSelector'
 import DocumentList from 'containers/DocumentList/DocumentList'
 import DocumentGridList from 'components/DocumentGridList/DocumentGridList'
 import DocumentListToolbar from 'components/DocumentListToolbar/DocumentListToolbar'
-import DropdownNative from 'components/DropdownNative/DropdownNative'
 import Header from 'containers/Header/Header'
 import HeroMessage from 'components/HeroMessage/HeroMessage'
 import Main from 'components/Main/Main'
@@ -23,17 +22,10 @@ import Style from 'lib/Style'
 import styles from './MediaListView.css'
 
 const BULK_ACTIONS = {
-  DELETE: 'BULK_ACTIONS_DELETE',
-  PLACEHOLDER: 'BULK_ACTIONS_PLACEHOLDER'
+  DELETE: 'BULK_ACTIONS_DELETE'
 }
 
 class MediaListView extends Component {
-  constructor(props) {
-    super(props)
-
-    this.state.bulkActionSelected = BULK_ACTIONS.PLACEHOLDER
-  }
-
   componentDidUpdate(prevProps, prevState) {
     const {actions, state} = this.props
     const {isDeleting, list} = state.documents
@@ -64,22 +56,11 @@ class MediaListView extends Component {
   }
 
   handleBulkActionApply(actionType) {
-    const {state} = this.props    
-    const {bulkActionSelected} = this.state
-    const validBulkActionSelected = bulkActionSelected &&
-      (bulkActionSelected !== BULK_ACTIONS.PLACEHOLDER)
+    const {state} = this.props
 
-    if (!validBulkActionSelected) return
-
-    if (bulkActionSelected === BULK_ACTIONS.DELETE) {
+    if (actionType === BULK_ACTIONS.DELETE) {
       this.handleDelete(state.documents.selected)
     }
-  }
-
-  handleBulkActionSelect(value) {
-    this.setState({
-      bulkActionSelected: value
-    })
   }
 
   handleDelete(ids) {
@@ -178,28 +159,14 @@ class MediaListView extends Component {
             page
           })}
         >
-          <div>
-            <DropdownNative
-              className={styles['bulk-action-select']}
-              onChange={this.handleBulkActionSelect.bind(this)}
-              options={{
-                [BULK_ACTIONS.DELETE]: 'Delete'
-              }}
-              placeholderLabel="With selected..."
-              placeholderValue={BULK_ACTIONS.PLACEHOLDER}
-              textSize="small"
-              value={bulkActionSelected}
-            />
-
-            <ButtonWithPrompt
-              accent="data"
-              disabled={(bulkActionSelected === BULK_ACTIONS.PLACEHOLDER) || !selectedDocuments.length}
-              onClick={this.handleBulkActionApply.bind(this)}
-              promptCallToAction={`Yes, delete ${selectedDocuments.length > 1 ? 'them' : 'it'}.`}
-              promptMessage={`Are you sure you want to delete the selected ${selectedDocuments.length > 1 ? 'documents' : 'document'}?`}
-              size="small"
-            >Apply</ButtonWithPrompt>
-          </div>        
+          <BulkActionSelector
+            actions={{
+              [BULK_ACTIONS.DELETE]: 'Delete'
+            }}
+            className={styles['bulk-action-select']}
+            onChange={this.handleBulkActionApply.bind(this)}
+            selection={selectedDocuments}
+          />       
         </DocumentListToolbar>
       </Page>
     )


### PR DESCRIPTION
🔍  Available for testing at http://publish-feature-mobile-improvements.eb.dev.dadi.technology/

---

# 1. Menu not visible after sign-in

Fixes an issue where, after signing in, the scroll position made it so that the nav menu wasn't visible unless the user scrolled up.

# 2. Toolbar fixed on mobile

Fixes an issue where not having enough content on the table view pushed the bottom toolbar to the middle of the screen. Now it's anchored to the bottom of the screen.

## Before

![image from ios 1 1](https://user-images.githubusercontent.com/4162329/51049997-54639b80-15c7-11e9-9d06-78a1c72235e1.png)

## After

![img_0683](https://user-images.githubusercontent.com/4162329/51050013-5cbbd680-15c7-11e9-8da2-2239428eccc7.png)

# 3. Compress header

Reduces the size of the "Create new" button, making it on the same line as the filters and therefore reducing the amount of vertical space used.

## Before

![img_0682](https://user-images.githubusercontent.com/4162329/51050082-8bd24800-15c7-11e9-8b5a-e4f7d87fc5d8.png)

## After

<img width="396" alt="screenshot 2019-01-11 at 14 32 21" src="https://user-images.githubusercontent.com/4162329/51050099-95f44680-15c7-11e9-8729-1e4ef63e960b.png">

# 4. Tighten up toolbar

For space optimisation, simplifies the pagination elements on the bottom toolbar by:

1. Removing the individual page numbers in favour of the Prev/Next buttons
1. Removing the "Showing x of y" label in favour of a new "go to page" input element, where a dropdown allows people to quickly select a page, taking advantage of the native elements from the mobile browser
1. Showing the bulk action selector only when there are documents selected, hiding it otherwise

## Before

![img_0682](https://user-images.githubusercontent.com/4162329/51050429-afe25900-15c8-11e9-931a-88d68adda446.png)

## After

![img_0691](https://user-images.githubusercontent.com/4162329/51116841-1f905800-1804-11e9-9162-857a8646da48.PNG)
![img_0692](https://user-images.githubusercontent.com/4162329/51116843-1f905800-1804-11e9-8c8e-1300b764c317.PNG)
![img_0686](https://user-images.githubusercontent.com/4162329/51050459-d3a59f00-15c8-11e9-9dab-3b980d5855e1.png)