### PR TITLE
Make sidebar not sticky

### DIFF
--- a/frontend/components/EditInterface/EditInterface.css
+++ b/frontend/components/EditInterface/EditInterface.css
@@ -50,8 +50,6 @@
 
 .sidebar {
   width: 100%;
-  position: sticky;
-  top: 0;
 }
 
 @media (--breakpoint-medium) {


### PR DESCRIPTION
This PR removes `position: sticky;` from the sidebar on the document edit view, to make scrolling easier.

/cc @josephdenne 