### PR TITLE
Handle singleton property in collection options

### DIFF
--- a/app/views/DocumentListView/DocumentListView.jsx
+++ b/app/views/DocumentListView/DocumentListView.jsx
@@ -213,7 +213,6 @@ class DocumentListView extends React.Component {
     const {metadata, results, dirty} = data
     const {page, totalPages} = metadata || {}
     const isSingleton = Boolean(collection.settings.publish && collection.settings.publish.singleton)
-
     if (isSingleton && !dirty && results && results.length > 0) {
       const redirectUrl = onBuildBaseUrl.call(this, {
         documentId: results[0]._id
@@ -275,7 +274,7 @@ class DocumentListView extends React.Component {
     return (
       <Page>
         <Header currentCllection={collection}>
-          {this.renderController({collection})}
+          {this.renderController({collection}, !isSingleton)}
         </Header>
 
         <Main>
@@ -287,25 +286,27 @@ class DocumentListView extends React.Component {
           })}
         </Main>
 
-        <DocumentListToolbar
-          documentsMetadata={data.metadata}
-          onBuildPageUrl={page => onBuildBaseUrl.call(this, {
-            page
-          })}
-          selectedDocuments={selection}
-          showSelectedDocumentsUrl={showSelectedDocumentsUrl}
-        >
-          <BulkActionSelector
-            actions={actions}
-            onChange={this.handleBulkActionApply.bind(this, collection)}
-            selection={selection}
-          />
-        </DocumentListToolbar>
+        { !isSingleton && (
+          <DocumentListToolbar
+            documentsMetadata={data.metadata}
+            onBuildPageUrl={page => onBuildBaseUrl.call(this, {
+              page
+            })}
+            selectedDocuments={selection}
+            showSelectedDocumentsUrl={showSelectedDocumentsUrl}
+          >
+            <BulkActionSelector
+              actions={actions}
+              onChange={this.handleBulkActionApply.bind(this, collection)}
+              selection={selection}
+            />
+          </DocumentListToolbar>
+        ) }
       </Page>
     )
   }
 
-  renderController({collection}) {
+  renderController({collection}, showFilters) {
     const {onBuildBaseUrl, route} = this.props
     const {search} = route
 
@@ -322,7 +323,7 @@ class DocumentListView extends React.Component {
       <DocumentListController
         collection={collection}
         createNewHref={createNewHref}
-        enableFilters={true}
+        enableFilters={showFilters}
         filters={search.filter}
         onUpdateFilters={this.handleFiltersUpdate.bind(this)}
       />

--- a/app/views/DocumentListView/DocumentListView.jsx
+++ b/app/views/DocumentListView/DocumentListView.jsx
@@ -210,8 +210,19 @@ class DocumentListView extends React.Component {
     // Getting documents from store.
     const contentKey = this.getContentKey()
     const data = state.documents[contentKey] || {}
-    const {metadata} = data
+    const {metadata, results, dirty} = data
     const {page, totalPages} = metadata || {}
+    const isSingleton = Boolean(collection.settings.publish && collection.settings.publish.singleton)
+
+    if (isSingleton && !dirty && results && results.length > 0) {
+      const redirectUrl = onBuildBaseUrl.call(this, {
+        documentId: results[0]._id
+      })
+
+      return (
+        <Redirect to={redirectUrl}/>
+      )
+    }
 
     // If the page parameter is higher than the number of pages available for
     // the current document set, we redirect to the last valid page.


### PR DESCRIPTION
Fix for: #584 

In this functionality, I assume that collection has `settings.publish.singleton` set to `true` to only accept one document inside.

If any document exists in the collection the user gets redirected to edit of the first document ordered in a way that API returns it.

If there is no document in the collection the user get information page as with a normal collection.