### PR TITLE
Remove trailing punctuation from truncated strings on list views

### DIFF
--- a/app/components/FieldString/FieldStringList.jsx
+++ b/app/components/FieldString/FieldStringList.jsx
@@ -86,7 +86,10 @@ export default class FieldStringList extends React.Component {
     maxLength = Math.floor(maxLength) || this.props.maxLength
 
     if (value.length > maxLength) {
-      return value.slice(0, maxLength - 1).trim() + '…'
+      // https://stackoverflow.com/a/25575009/8583207
+      const punctuation = /[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]+$/
+      
+      return value.slice(0, maxLength - 1).trim().replace(punctuation, '').trim() + '…'
     }
 
     return value

--- a/app/components/FieldString/FieldStringList.jsx
+++ b/app/components/FieldString/FieldStringList.jsx
@@ -88,8 +88,14 @@ export default class FieldStringList extends React.Component {
     if (value.length > maxLength) {
       // https://stackoverflow.com/a/25575009/8583207
       const punctuation = /[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]+$/
-      
-      return value.slice(0, maxLength - 1).trim().replace(punctuation, '').trim() + '…'
+
+      return (
+        value
+          .slice(0, maxLength - 1)
+          .trim()
+          .replace(punctuation, '')
+          .trim() + '…'
+      )
     }
 
     return value


### PR DESCRIPTION
Closes #688 

String values in list views are truncated with an ellipsis. This PR trims any punctuation marks which appear immediately before the ellipsis.