### PR TITLE
Route straight to edit view for single-document collections

### DIFF
--- a/app/containers/DocumentEditToolbar/DocumentEditToolbar.jsx
+++ b/app/containers/DocumentEditToolbar/DocumentEditToolbar.jsx
@@ -4,6 +4,7 @@ import * as documentActions from 'actions/documentActions'
 import * as userActions from 'actions/userActions'
 import {connectRedux} from 'lib/redux'
 import {connectRouter} from 'lib/router'
+import Button from 'components/Button/Button'
 import ButtonWithOptions from 'components/ButtonWithOptions/ButtonWithOptions'
 import ButtonWithPrompt from 'components/ButtonWithPrompt/ButtonWithPrompt'
 import DateTime from 'components/DateTime/DateTime'
@@ -37,6 +38,11 @@ class DocumentEditToolbar extends React.Component {
      * The ID of the document being edited.
      */
     documentId: proptypes.string,
+
+    /**
+     * Whether the collection is a single-document collection.
+     */
+    isSingleDoc: proptypes.bool,
 
     /**
      * Whether to render a control for selecting different languages.
@@ -141,6 +147,7 @@ class DocumentEditToolbar extends React.Component {
     const {
       contentKey,
       documentId,
+      isSingleDoc,
       multiLanguage,
       router,
       state
@@ -237,15 +244,26 @@ class DocumentEditToolbar extends React.Component {
           )}
 
           <div className={styles.button}>
-            <ButtonWithOptions
-              accent="save"
-              disabled={Boolean(
-                hasConnectionIssues || hasValidationErrors || isSaving
-              )}
-              isLoading={isSaving}
-              onClick={saveOptions.primary.action}
-              options={saveOptions.secondary}
-            >{saveOptions.primary.label}</ButtonWithOptions>
+            {isSingleDoc ? (
+              <Button
+                accent="save"
+                disabled={Boolean(
+                  hasConnectionIssues || hasValidationErrors || isSaving
+                )}
+                isLoading={isSaving}
+                onClick={saveOptions.primary.action}
+              >{saveOptions.primary.label}</Button>
+            ) : (
+              <ButtonWithOptions
+                accent="save"
+                disabled={Boolean(
+                  hasConnectionIssues || hasValidationErrors || isSaving
+                )}
+                isLoading={isSaving}
+                onClick={saveOptions.primary.action}
+                options={saveOptions.secondary}
+              >{saveOptions.primary.label}</ButtonWithOptions>
+            )}
           </div>
         </div>
       </Toolbar>


### PR DESCRIPTION
Closes #584 

This PR enables the flag `settings.publish.isSingleDocument` in the collection specification. This hints to Publish that the collection is supposed to only contain a single document.

With this flag set to `true`, routes `/collection` and `/group/collection` render the edit view instead of the list view, displaying either the first document in the collection, if there is one, or an empty editor for creating a new document.

Secondary save options ("Save and go back", "Save as a duplicate", "Save and create new") are removed from the save button for a single-document collection.

### Overview of code changes

App:
- Passing a render function `renderEditListSwitch()` to routes `/collection` and `/group/collection` instead of the `DocumentListView` component. The function reads the `isSingleDocument` flag and returns the proper component (`DocumentListView` or `DocumentEditView`).

DocumentEditView:
- Moved assignments to instance (`this`) properties from `render()` to a helper function `deriveInstanceProps()` so that the properties can be accessed before rendering.
- Added logic for fetching the document list for the collection.
- Refetching doc list on save/delete (L93–102) so that `this.documentId` can be properly re-read from the fetched doc list.
- Moved `documentId` to an instance property so that it can be set from the fetched doc list.

DocumentEditToolbar:
- Removed secondary actions from save button for single-doc collections.