### PR TITLE
Fix overlapping labels on fields

### DIFF
--- a/app/components/Label/Label.css
+++ b/app/components/Label/Label.css
@@ -2,34 +2,48 @@
   position: relative;
   background-color: #ffffff;
   border: 1px solid #efefef;
-  box-shadow: 2px 2px 10px 0 rgba(0,0,0,0.03);
+  box-shadow: 2px 2px 10px 0 rgba(0, 0, 0, 0.03);
   border-radius: 3px;
-  padding: 30px 13px 10px;
+  padding: 13px 13px 10px;
   display: block;
   transition: border-color 0.3s;
+}
+
+.header {
+  margin: -4px 0 6px -8px;
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.container-compact .header {
+  margin: -4px 0 0 2px; /* -8px for gutter + 10px actual margin */
+  flex: 1;
+  align-items: center;
+}
+
+.header > div {
+  margin: 4px 0 0 8px;
 }
 
 .container:hover,
 .container-focus {
   border-color: #dad7d7;
-  box-shadow: 2px 2px 10px 0 rgba(0,0,0,0.1);
+  box-shadow: 2px 2px 10px 0 rgba(0, 0, 0, 0.1);
 }
 
 .container-compact {
   display: flex;
+  flex-direction: row-reverse;
   align-items: center;
   padding: 8px 13px;
   cursor: pointer;
 }
 
-.container-compact.container-with-comment {
-  padding: 15px 80px 15px 13px;
-}
-
 .container-error {
   background-color: #fef8f8;
   box-shadow: 2px 2px 10px 0 rgba(255, 46, 46, 0.23);
-  border-color: #E5462C;
+  border-color: #e5462c;
 }
 
 .container-error-message {
@@ -38,42 +52,27 @@
 
 .container-compact .label {
   font-size: 15px;
-  margin-left: 10px;
 }
 
 .container-compact:hover .label {
-  color: var(--theme-colour-primary,#000)
+  color: var(--theme-colour-primary, #000);
 }
 
 .container:not(.container-compact) .label {
-  position: absolute;
-  top: 13px;
-  left: 14px;
   font-weight: 700;
-}
-
-.comment {
-  position: absolute;
-  top: 13px;
-  right: 14px;
-}
-
-.container-compact .comment {
-  top: 50%;
-  transform: translateY(-50%);
 }
 
 .comment,
 .label {
-  color: var(--theme-colour-primary-shade-1, #FAFAFA);
+  color: var(--theme-colour-primary-shade-1, #fafafa);
   font-family: var(--theme-font-family, sans-serif);
   font-size: var(--theme-font-size-small, 13px);
 }
 
 .error-message {
   display: inline-block;
-  background-color: #E5462C;
-  color: #FFFFFF;
+  background-color: #e5462c;
+  color: #ffffff;
   padding: 5px 8px;
   font-weight: bold;
   font-family: var(--theme-font-family, sans-serif);

--- a/app/components/Label/Label.jsx
+++ b/app/components/Label/Label.jsx
@@ -125,12 +125,13 @@ export default class Label extends React.Component {
 
     return (
       <label htmlFor={this.id} className={labelStyle.getClasses()}>
-        {this.renderChildren()}
-
-        <div className={styles.label}>{label || ''}</div>
-
-        {comment && <sub className={styles.comment}>{comment}</sub>}
-
+        {(label || comment) && (
+          <div className={styles.header}>
+            <div className={styles.label}>{label || ''}</div>
+            {comment && <div className={styles.comment}>{comment}</div>}
+          </div>
+        )}
+        <div>{this.renderChildren()}</div>
         {errorMessage && (
           <p className={styles['error-message']}>{errorMessage}</p>
         )}


### PR DESCRIPTION
Closes #646 

Flexbox ftw!

For clarity: for the `.header` I used the pattern of 

```css
.someElement {
  margin: -x 0 0 -y;
}

.someElement > div {
  margin: x 0 0 y;
}
```

which puts a gutter between the children elements without changing the outer margins of the cointaining element.

### Preview

![Screenshot_2019-06-26 Edit document DADI Publish(3)](https://user-images.githubusercontent.com/21290049/60170347-8d579b80-9808-11e9-888d-15397cd678cd.png)
![Screenshot_2019-06-26 Edit document DADI Publish(4)](https://user-images.githubusercontent.com/21290049/60170351-9183b900-9808-11e9-94a5-8a6794973d5f.png)
![Screenshot_2019-06-26 Edit document DADI Publish(5)](https://user-images.githubusercontent.com/21290049/60170357-93e61300-9808-11e9-82f7-e241fd221b65.png)
