### PR TITLE
Fix overflow in reference field

### DIFF
--- a/app/components/FieldReference/FieldReference.css
+++ b/app/components/FieldReference/FieldReference.css
@@ -2,16 +2,25 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background-color: var(--theme-colour-background-shade-1, #FAFAFA);
-  border: 1px solid var(--theme-colour-background-shade-4, #E4E4E4);
+  background-color: var(--theme-colour-background-shade-1, #fafafa);
+  border: 1px solid var(--theme-colour-background-shade-4, #e4e4e4);
   border-radius: 5px;
   padding: 5px;
   padding-left: 10px;
   margin: 3px 0;
 }
 
+.list-value-container {
+  display: flex;
+}
+
 .values {
-  width: 100%;
+  flex-basis: auto;
+  min-width: 0; /* https://css-tricks.com/flexbox-truncated-text/ */
+}
+
+.buttons {
+  display: flex;
 }
 
 .value {
@@ -21,18 +30,25 @@
   padding-top: 2px;
 }
 
+.value,
+.list-value {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .empty {
-  color: var(--theme-colour-background-shade-2, #AAAAAA);
+  color: var(--theme-colour-background-shade-2, #aaaaaa);
 }
 
 .value-link {
-  display: inline-block;
-  border-bottom: 1px solid var(--theme-colour-background-shade-4, #E4E4E4);
+  display: block;
+  border-bottom: 1px solid var(--theme-colour-background-shade-4, #e4e4e4);
   margin-top: 5px;
+  margin-right: 23px;
   position: relative;
-  clear: both;
-  float: left;
 }
+
 .value-link:first-of-type {
   margin-top: 0;
 }
@@ -53,7 +69,7 @@
 }
 
 .value-link:hover {
-  border-bottom-color: var(--theme-colour-data, #4A91FF)
+  border-bottom-color: var(--theme-colour-data, #4a91ff);
 }
 
 .placeholder {
@@ -70,7 +86,7 @@
 }
 
 .list-head-annotation {
-  background: rgba(0,0,0,0.2);
+  background: rgba(0, 0, 0, 0.2);
   color: #000000;
   font-size: 10px;
   font-family: var(--theme-font-family, sans-serif);

--- a/app/components/FieldReference/FieldReferenceEdit.jsx
+++ b/app/components/FieldReference/FieldReferenceEdit.jsx
@@ -178,10 +178,10 @@ export default class FieldReferenceEdit extends React.Component {
                       href={`${referencedCollection._publishLink}/${value._id}`}
                       key={value._id}
                     >
-                      <span className={styles.value}>
+                      <div className={styles.value}>
                         {(displayField && value[displayField]) ||
                           `Referenced ${displayName}`}
-                      </span>
+                      </div>
                     </a>
                   )
                 }
@@ -194,27 +194,29 @@ export default class FieldReferenceEdit extends React.Component {
               })}
             </div>
 
-            {!isReadOnly && (
-              <Button
-                accent="data"
-                className={styles['control-button']}
-                href={editLink}
-                size="small"
-              >
-                Edit
-              </Button>
-            )}
+            <div className={styles.buttons}>
+              {!isReadOnly && (
+                <Button
+                  accent="data"
+                  className={styles['control-button']}
+                  href={editLink}
+                  size="small"
+                >
+                  Edit
+                </Button>
+              )}
 
-            {!isReadOnly && (
-              <Button
-                accent="destruct"
-                className={styles['control-button']}
-                onClick={this.handleRemove.bind(this)}
-                size="small"
-              >
-                Remove
-              </Button>
-            )}
+              {!isReadOnly && (
+                <Button
+                  accent="destruct"
+                  className={styles['control-button']}
+                  onClick={this.handleRemove.bind(this)}
+                  size="small"
+                >
+                  Remove
+                </Button>
+              )}
+            </div>
           </div>
         )}
 

--- a/app/components/FieldReference/FieldReferenceList.jsx
+++ b/app/components/FieldReference/FieldReferenceList.jsx
@@ -61,26 +61,31 @@ export default class FieldReferenceList extends React.Component {
 
     if (values) {
       return (
-        <div className={styles.values}>
-          {values.map(val => {
-            const collection = schema.settings.collection
-            const editLink = `${referencedCollection._publishLink}/${val._id}`
-            const displayField =
-              (optionsBlock && optionsBlock.displayField) || firstStringField
-                ? firstStringField.key
-                : null
+        <div className={styles['list-value-container']}>
+          <div className={styles.values}>
+            {values.map(val => {
+              const collection = schema.settings.collection
+              const editLink = `${referencedCollection._publishLink}/${val._id}`
+              const displayField =
+                (optionsBlock && optionsBlock.displayField) || firstStringField
+                  ? firstStringField.key
+                  : null
 
-            return (
-              <Link
-                className={styles['value-link']}
-                key={editLink}
-                to={editLink}
-              >
-                {(displayField && val[displayField]) ||
-                  `Referenced ${collection}`}
-              </Link>
-            )
-          })}
+              return (
+                <Link
+                  className={styles['value-link']}
+                  key={editLink}
+                  to={editLink}
+                >
+                  <div className={styles['list-value']}>
+                    {(displayField && val[displayField]) ||
+                      `Referenced ${collection}`}
+                  </div>
+                </Link>
+              )
+            })}
+          </div>
+          <div />
         </div>
       )
     }


### PR DESCRIPTION
Closes #685 

A quick fix to avoid breaking UI for now; ideally a more substantial fix would refactor the component to make the CSS a bit less unwieldy, but I expect an overhaul of the UI at some point in not so distant future, so I don't wanna invest too much time into this.

![Screenshot_2019-06-28 Edit document DADI Publish](https://user-images.githubusercontent.com/21290049/60334942-fe2fbc80-999c-11e9-97d0-4c6195e01124.png)
![Screenshot_2019-06-28 Edit document DADI Publish(1)](https://user-images.githubusercontent.com/21290049/60334946-fff98000-999c-11e9-8d78-f58488d98b2a.png)
![Screenshot_2019-06-28 Reference Field Testing DADI Publish](https://user-images.githubusercontent.com/21290049/60334949-025bda00-999d-11e9-8293-5b2eb1d4e37c.png)
