### PR TITLE
Allow deselecting all references

### DIFF
--- a/app/views/ReferenceSelectView/ReferenceSelectView.jsx
+++ b/app/views/ReferenceSelectView/ReferenceSelectView.jsx
@@ -69,7 +69,7 @@ class ReferenceSelectView extends React.Component {
     actions.updateLocalDocument({
       contentKey: this.getParentContentKey(),
       update: {
-        [referenceField]: selection
+        [referenceField]: selection && selection.length > 0 ? selection : null
       }
     })
 
@@ -368,14 +368,12 @@ class ReferenceSelectView extends React.Component {
                 >
                   <Button
                     accent="save"
-                    disabled={selection.length === 0}
                     onClick={this.handleDocumentSelect.bind(this, {
                       referenceField,
                       selection
                     })}
                   >
-                    Add selected{' '}
-                    {selection.length === 1 ? 'document' : 'documents'}
+                    Save selection
                   </Button>
                 </DocumentListToolbar>
               </div>

--- a/test/functional/pages/Article.js
+++ b/test/functional/pages/Article.js
@@ -60,7 +60,7 @@ module.exports = {
       'Number of Network Services'
     ),
     addAuthor: locate('button')
-      .withText('Add selected document')
+      .withText('Save selection')
       .as('Add The Author'),
     excerptField: locate('div')
       .withAttr({
@@ -127,7 +127,7 @@ module.exports = {
       .withText('Select existing network service')
       .as('Select Existing Newtork Service Button'),
     addSelected: locate('button')
-      .withText('Add selected document')
+      .withText('Save selection')
       .as('Add Selected Document Button'),
     removeNetworkButton: locate('div')
       .withAttr({

--- a/test/functional/pages/Field.js
+++ b/test/functional/pages/Field.js
@@ -453,7 +453,7 @@ module.exports = {
       .as('Reference required error box'),
     numOfAuthors: locate('//table/tbody/tr/td[2]').as('Number of Authors'),
     addAuthor: locate('button')
-      .withText('Add selected document')
+      .withText('Save selection')
       .as('Add The Author'),
     referenceLink: locate('a[class*="FieldReference__value-link"]').as(
       'Added reference'
@@ -615,7 +615,7 @@ module.exports = {
       .find('div[class*="FieldMedia__upload-drop"]')
       .as('Drop files to upload PDF Only'),
     addSelected: locate('button')
-      .withText('Add selected document')
+      .withText('Save selection')
       .as('Add Selected Document Button'),
     mediaJpegAdded: locate('div')
       .withAttr({


### PR DESCRIPTION
Closes #739 

I changed the text of the button from "add selected document(s)" to "save selection", because you're not always *adding* documents. What do you think?