### PR TITLE
Fix a few minor datetime bugs

### DIFF
--- a/app/components/TextInput/TextInput.jsx
+++ b/app/components/TextInput/TextInput.jsx
@@ -169,16 +169,15 @@ export default class TextInput extends React.Component {
   }
 
   componentDidUpdate(oldProps) {
-    const {oldHeightType} = oldProps
-    const {heightType, inputRef} = this.props
+    const {heightType: oldHeightType, value: oldValue} = oldProps
+    const {heightType, inputRef, value} = this.props
 
     if (oldHeightType !== heightType && heightType === 'content') {
       this.adjustHeightIfNeeded()
     }
 
-    if (this.cursor) {
+    if (oldValue !== value && this.cursor) {
       this.setCursor(this.cursor)
-      this.cursor = null
     }
 
     if (typeof inputRef === 'function') {

--- a/app/components/TextInputWithDatePicker/TextInputWithDatePicker.jsx
+++ b/app/components/TextInputWithDatePicker/TextInputWithDatePicker.jsx
@@ -141,26 +141,24 @@ export default class TextInputWithDatePicker extends React.Component {
     const {value} = event.target
     const newDate = new DateTime(event.target.value, format)
 
-    if (value.length > 0) {
-      if (value.length === format.length && newDate.isValid()) {
-        if (typeof onChange === 'function') {
-          const utcDate = newDate.getDate({toUTC: true})
+    if (value.length === format.length && newDate.isValid()) {
+      if (typeof onChange === 'function') {
+        const utcDate = newDate.getDate({toUTC: true})
 
-          onChange(utcDate.getTime())
-        }
-
-        this.setState({
-          internalValue: null
-        })
-      } else {
-        if (typeof onChange === 'function') {
-          onChange(null)
-        }
-
-        this.setState({
-          internalValue: value
-        })
+        onChange(utcDate.getTime())
       }
+
+      this.setState({
+        internalValue: null
+      })
+    } else {
+      if (typeof onChange === 'function') {
+        onChange(null)
+      }
+
+      this.setState({
+        internalValue: value
+      })
     }
   }
 

--- a/app/lib/datetime.js
+++ b/app/lib/datetime.js
@@ -23,10 +23,8 @@ export default class DateTime {
     // Unix timestamp in a string.
     if (intDate.toString() === date) return new Date(intDate)
 
-    let parsedDate
-
     try {
-      parsedDate =
+      const parsedDate =
         // Fecha requires a format. If no format is specified, try ISO.
         fecha.parse(date, format || FORMAT_ISO8601) ||
         // If format is specified but parsing fails, the value has probably been

--- a/app/lib/datetime.js
+++ b/app/lib/datetime.js
@@ -13,52 +13,34 @@ export default class DateTime {
   }
 
   _parse(date, format) {
-    // If `date` is already a Date object, there's nothing we need
-    // to do.
-    if (date instanceof Date) {
-      return date
-    } else if (typeof date === 'number') {
-      // If it's a number, we assume it's a timestamp, so we create a date
-      // from that. We'll assume the timestamp is in seconds, so we need to
-      // convert to milliseconds when passing to Date().
-      return new Date(date)
-    } else if (typeof date === 'string') {
-      // If there is a `format` specified, we'll try to parse the date using
-      // that.
-      if (format && format !== 'unix') {
-        try {
-          const parsedDate = fecha.parse(date, format)
+    if (date instanceof Date) return date
 
-          // If the date was not parsed correctly, let's pass it through the
-          // parsing function again, but this time without a format. It may
-          // be that it's picked up as either a numeric timestamp or ISO8601.
-          if (parsedDate === null) {
-            return this._parse(date, null)
-          }
+    // Unix timestamp.
+    if (typeof date === 'number') return new Date(date)
 
-          // When parsing a date from a string, it'll be parsed to the local
-          // time, which we do not want. So we get a new date that is computed
-          // by applying the timezone offset, which effectively means parsing
-          // the string as a UTC date.
-          return this._getLocalDateFromUTCDate(parsedDate)
-        } catch (err) {
-          console.error('Error parsing date', err)
+    const intDate = parseInt(date, 10)
 
-          return null
-        }
-      } else {
-        const intDate = parseInt(date)
+    // Unix timestamp in a string.
+    if (intDate.toString() === date) return new Date(intDate)
 
-        // It might be that the input date is still a timestamp, but represented
-        // as a string. If that's the case, we use the parsed int and treat it
-        // as a timestamp.
-        if (intDate.toString() === date) {
-          return new Date(intDate)
-        }
+    let parsedDate
 
-        // We assume the input string is in ISO8601 format.
-        return this._parse(date, FORMAT_ISO8601)
-      }
+    try {
+      parsedDate =
+        // Fecha requires a format. If no format is specified, try ISO.
+        fecha.parse(date, format || FORMAT_ISO8601) ||
+        // If format is specified but parsing fails, the value has probably been
+        // received from API which stores the values in ISO string format. Try ISO.
+        fecha.parse(date, FORMAT_ISO8601)
+
+      // Fecha parses the string as a local date; we want to parse it as a UTC date.
+      // The conversion method adds back the difference from UTC, so that the string
+      // argument is effectively parsed as a UTC date.
+      return this._getLocalDateFromUTCDate(parsedDate)
+    } catch (error) {
+      console.error('Error while parsing date:', error)
+
+      return null
     }
   }
 


### PR DESCRIPTION
I put a few fixes together into a single PR, because they're tiny.

### Bugs fixed:

1. **When manually typing a date into a date input field, the app would go into an infinite loop and freeze.**
1. When manually typing the date, after going from an invalid value to a valid one, the cursor would jump to the end of the input.
1. The date input field would not allow deleting the value completely.

Also, I fixed an unrelated potential bug in `TextInput` (in fortunately otherwise unused code):
```javascript
const {oldHeightType} = oldProps
```
changed to
```javascript
const {heightType: oldHeightType} = oldProps
```