### PR TITLE
Fix position of link input in rich editor

### DIFF
--- a/app/components/RichEditor/RichEditor.jsx
+++ b/app/components/RichEditor/RichEditor.jsx
@@ -162,6 +162,12 @@ export default class RichEditor extends React.Component {
     }
   }
 
+  componentDidUpdate(_, prevState) {
+    if (this.state.isFullscreen !== prevState.isFullscreen) {
+      this.containerBounds = this.container.getBoundingClientRect()
+    }
+  }
+
   componentWillMount() {
     this.hotKeys.removeListener()
   }
@@ -500,10 +506,7 @@ export default class RichEditor extends React.Component {
     const valueIsLink = this.hasInline(NODE_LINK)
 
     return (
-      <div
-        className={containerStyle.getClasses()}
-        ref={el => (this.container = el)}
-      >
+      <div className={containerStyle.getClasses()}>
         {isSelectingMedia && (
           <Modal
             onRequestClose={this.handleToggleMediaSelect.bind(this, false)}
@@ -605,7 +608,10 @@ export default class RichEditor extends React.Component {
           </div>
         </RichEditorToolbar>
 
-        <div className={editorWrapperStyle.getClasses()}>
+        <div
+          className={editorWrapperStyle.getClasses()}
+          ref={el => (this.container = el)}
+        >
           <Editor
             className={styles.editor}
             onChange={this.handleChange.bind(this)}

--- a/app/components/RichEditor/RichEditorLink.css
+++ b/app/components/RichEditor/RichEditorLink.css
@@ -32,11 +32,8 @@ input:focus {
 .popup {
   background-color: black;
   border-radius: 4px;
-  bottom: 100%;
   box-shadow: 7px 6px 25px rgba(0, 0, 0, 0.3);
   color: white;
-  left: 0;
-  margin: 6px 0 10px 0;
   padding: 5px 10px;
   position: absolute;
   z-index: 10;


### PR DESCRIPTION
Closes #746 

Displays the link input above the beginning of the link, unless that would go above the top of the editor, in which case it displays the link input below the beginning of the link.